### PR TITLE
fix: remove estado espelhado e overflow do aviso

### DIFF
--- a/src/components/notification.tsx
+++ b/src/components/notification.tsx
@@ -1,33 +1,20 @@
-import { useEffect, useState } from "react";
-
 interface NotificationProps {
   text: string;
   active: boolean;
 }
 
-export const Notification: React.FC<NotificationProps> = ({ text, active }) => {
-  const [isVisible, setIsVisible] = useState<boolean>(active);
-
-  useEffect(() => {
-    if (active) {
-      setIsVisible(true);
-    } else {
-        setIsVisible(false);
-    }
-  }, [active]);
-
-  if (!isVisible) return null;
+export const Notification = ({ text, active }: NotificationProps) => {
+  if (!active) return null;
 
   return (
-    <div className="w-full h-screen z-50 fixed pointer-events-none">
+    <div className="pointer-events-none fixed inset-0 z-50">
       <div
-        id="toast-warning"
-        className="flex items-center w-full max-w-xs p-4 text-gray-500 bg-zinc-200 rounded-lg shadow right-4 absolute top-5"
+        className="absolute top-5 right-4 left-4 ml-auto flex max-w-xs items-center rounded-lg bg-zinc-200 p-4 text-zinc-600 shadow"
         role="alert"
       >
-        <div className="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-orange-500 bg-orange-100 rounded-lg dark:bg-orange-700 dark:text-orange-200">
+        <div className="inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-500">
           <svg
-            className="w-5 h-5"
+            className="h-5 w-5"
             aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="currentColor"
@@ -35,7 +22,6 @@ export const Notification: React.FC<NotificationProps> = ({ text, active }) => {
           >
             <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM10 15a1 1 0 1 1 0-2 1 1 0 0 1 0 2Zm1-4a1 1 0 0 1-2 0V6a1 1 0 0 1 2 0v5Z" />
           </svg>
-          <span className="sr-only">Warning icon</span>
         </div>
         <div className="ml-3 text-sm font-normal">{text}</div>
       </div>


### PR DESCRIPTION
O componente mantinha um `useState` que apenas copiava a prop `active` dentro de um `useEffect`, gerando um render extra e atrasando o aviso em um paint. A regra `react-hooks/set-state-in-effect` acusa esse padrão como erro. A visibilidade agora vem direto da prop.

O balão usava `w-full max-w-xs` ancorado em `right-4`: em telas de até 320px a largura resolvia para a viewport inteira e ele vazava pela borda esquerda. Passa a `left-4 right-4` com `ml-auto`. Verificado a 320px: o balão fica entre 16px e 304px.

Removidos as variantes `dark:` do ícone num app sem tema escuro, o `id` que ninguém referenciava e o texto de leitor de tela em inglês, redundante com o `role="alert"`.