### PR TITLE
fix: corrige semântica, links externos e bordas de navbar e footer

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,31 +1,47 @@
-import { BentoMeIcon, GithubIcon, InstagramIcon, LinkedInIcon, YouTubeIcon } from "./icons"
-import { siteConfig } from "./links"
+import {
+  BentoMeIcon,
+  GithubIcon,
+  InstagramIcon,
+  LinkedInIcon,
+  YouTubeIcon,
+} from "./icons";
+import { siteConfig } from "./links";
+
+// Avaliado no import: chamar new Date() durante o render quebraria a
+// pureza que o React Compiler exige.
+const CURRENT_YEAR = new Date().getFullYear();
+
+const SOCIAL_LINKS = [
+  { label: "GitHub", href: siteConfig.links.github, Icon: GithubIcon },
+  { label: "LinkedIn", href: siteConfig.links.linkedin, Icon: LinkedInIcon },
+  { label: "Instagram", href: siteConfig.links.instagram, Icon: InstagramIcon },
+  { label: "Bento", href: siteConfig.links.bento, Icon: BentoMeIcon },
+  { label: "YouTube", href: siteConfig.links.youtube, Icon: YouTubeIcon },
+];
 
 export const Footer = () => {
   return (
-    <footer className="bg-zinc-200 border-b border-zinc-950/10 shadow-[0px_-3px_12px_-8px_rgba(0,_0,_0,_1)] text-center py-2 z-50 fixed bottom-0 w-full flex justify-center items-center">
-      <div className="items-center justify-between max-w-[1024px] container md:mx-6 flex-grow md:flex md:items-center mx-auto md:justify-between">
-        <div className="text-center mb-1 font-medium">
-          © 2025 Kohako.dev, Inc. All rights reserved.
-        </div>
-        <div className="flex justify-center items-center space-x-2">
-          <a href={siteConfig.links.github}>
-            <GithubIcon className="text-zinc-800" />
-          </a>
-          <a href={siteConfig.links.linkedin}>
-            <LinkedInIcon className="text-zinc-800" />
-          </a>
-          <a href={siteConfig.links.instagram}>
-            <InstagramIcon className="text-zinc-800"  />
-          </a>
-          <a href={siteConfig.links.bento}>
-            <BentoMeIcon className="text-zinc-800" />
-          </a>
-          <a href={siteConfig.links.youtube}>
-            <YouTubeIcon className="text-zinc-800" />
-          </a>
-        </div>
+    <footer className="fixed bottom-0 z-50 flex w-full items-center justify-center border-t border-zinc-950/10 bg-zinc-200 py-2 text-center font-poppins shadow-[0px_-3px_12px_-8px_rgba(0,_0,_0,_1)]">
+      <div className="mx-auto flex w-full max-w-[1024px] flex-col items-center justify-between gap-y-1 px-4 sm:px-6 md:flex-row">
+        <p className="font-medium">
+          © {CURRENT_YEAR} Kohako.dev, Inc. All rights reserved.
+        </p>
+        <ul className="flex items-center justify-center gap-x-2">
+          {SOCIAL_LINKS.map(({ label, href, Icon }) => (
+            <li key={label}>
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={label}
+                className="inline-flex rounded text-zinc-800 transition-colors hover:text-zinc-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-900"
+              >
+                <Icon />
+              </a>
+            </li>
+          ))}
+        </ul>
       </div>
     </footer>
-  )
-}
+  );
+};

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,15 +1,16 @@
 export const Navbar = () => {
   return (
-    <footer className="bg-zinc-200 border-b border-zinc-950/10 shadow-[0px_-3px_12px_-8px_rgba(0,_0,_0,_1)] text-center py-2 z-50 fixed top-0 w-full flex justify-center items-center font-poppins">
-      <div className="items-center justify-between max-w-[1024px] container flex-grow flex md:items-center mx-6">
-        <a href="" className="text-center font-medium flex gap-x-1 cursor-pointer">
-          <img className="invert w-3 object-contain mb-0.5" src="/KWK.png" alt="Logo" />
+    <header className="fixed top-0 z-50 flex w-full items-center justify-center border-b border-zinc-950/10 bg-zinc-200 py-2 text-center font-poppins shadow-[0px_3px_12px_-8px_rgba(0,_0,_0,_1)]">
+      <nav className="mx-auto flex w-full max-w-[1024px] items-center justify-between px-4 sm:px-6">
+        <a
+          href="/"
+          className="flex items-center gap-x-1 rounded font-medium focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-900"
+        >
+          <img className="mb-0.5 w-3 object-contain invert" src="/KWK.png" alt="" />
           KWK
         </a>
-        <div className="flex justify-center items-center space-x-2 font-medium">
-            Bin2Dec
-        </div>
-      </div>
-    </footer>
-  )
-}
+        <p className="font-medium">Bin2Dec</p>
+      </nav>
+    </header>
+  );
+};


### PR DESCRIPTION
Navbar: a barra de topo era marcada como `<footer>`, deixando a página com dois landmarks `contentinfo` e nenhum `banner`; o logo apontava para `href=""`, que recarrega a página em vez de navegar; e a sombra tinha deslocamento vertical negativo, ou seja, projetada para cima e portanto invisível numa barra fixa no topo.

Footer: usava `border-b` estando fixo no rodapé, com a borda desenhada fora da área visível. Os cinco links de rede social não tinham nome acessível — os SVGs são `aria-hidden`, então o leitor de tela anunciava apenas "link", cinco vezes (WCAG 2.4.4 e 4.1.2). Abriam na mesma aba, sem `rel`, e nenhum tinha indicador de foco visível.

O ano do copyright era fixo em 2025 e passa a ser calculado no escopo do módulo, não no render, para não violar a pureza exigida pelo React Compiler. Os cinco blocos repetidos viraram um `map`, e o footer recebeu `font-poppins`, que só ele não tinha.