### PR TITLE
fix: corrige moldura e rolagem da tabela de exemplos

### DIFF
--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -1,43 +1,54 @@
+const CONVERSIONS = [
+  { id: 1, binary: "1010", decimal: 10 },
+  { id: 2, binary: "1101", decimal: 13 },
+  { id: 3, binary: "1110", decimal: 14 },
+  { id: 4, binary: "1001", decimal: 9 },
+  { id: 5, binary: "1111", decimal: 15 },
+];
+
 export const Table = () => {
-    const conversions = [
-      { id: 1, binary: '1010', decimal: 10 },
-      { id: 2, binary: '1101', decimal: 13 },
-      { id: 3, binary: '1110', decimal: 14 },
-      { id: 4, binary: '1001', decimal: 9 },
-      { id: 5, binary: '1111', decimal: 15 },
-    ];
-  
-    return (
-      <div className="flex flex-col w-full max-w-[585px] rounded-xl shadow-[6px_6px_26px_#9b9b9d,-6px_-6px_26px_#ffffff]">
-        <div className="overflow-x-auto sm:-mx-6 lg:-mx-8">
-          <div className="inline-block min-w-full py-2 sm:px-6 lg:px-8">
-            <div className="overflow-hidden">
-              <table className="min-w-full text-left text-sm font-light text-surface">
-                <thead className="border-b border-neutral-200 font-medium dark:border-white/10">
-                  <tr>
-                    <th scope="col" className="px-6 py-4">#</th>
-                    <th scope="col" className="px-6 py-4">Binário</th>
-                    <th scope="col" className="px-6 py-4">Decimal</th>
-                    <th scope="col" className="px-6 py-4">Conversão</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {conversions.map(({ id, binary, decimal }) => (
-                    <tr key={id} className="border-b border-neutral-200 dark:border-white/10">
-                      <td className="whitespace-nowrap px-6 py-4 font-medium">{id}</td>
-                      <td className="whitespace-nowrap px-6 py-4">{binary}</td>
-                      <td className="whitespace-nowrap px-6 py-4">{decimal}</td>
-                      <td className="whitespace-nowrap px-6 py-4">
-                        {binary} → {decimal} / {decimal} → {binary}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
+  return (
+    <div className="w-full max-w-[585px] overflow-hidden rounded-xl shadow-[6px_6px_26px_#9b9b9d,-6px_-6px_26px_#ffffff]">
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-left text-sm font-light text-zinc-800">
+          <caption className="sr-only">
+            Exemplos de conversão entre binário e decimal
+          </caption>
+          <thead className="border-b border-zinc-950/10 font-medium">
+            <tr>
+              <th scope="col" className="px-3 py-4 sm:px-6">
+                #
+              </th>
+              <th scope="col" className="px-3 py-4 sm:px-6">
+                Binário
+              </th>
+              <th scope="col" className="px-3 py-4 sm:px-6">
+                Decimal
+              </th>
+              <th scope="col" className="px-3 py-4 sm:px-6">
+                Conversão
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {CONVERSIONS.map(({ id, binary, decimal }) => (
+              <tr key={id} className="border-b border-zinc-950/10 last:border-0">
+                <th
+                  scope="row"
+                  className="px-3 py-4 font-medium whitespace-nowrap sm:px-6"
+                >
+                  {id}
+                </th>
+                <td className="px-3 py-4 whitespace-nowrap sm:px-6">{binary}</td>
+                <td className="px-3 py-4 whitespace-nowrap sm:px-6">{decimal}</td>
+                <td className="px-3 py-4 whitespace-nowrap sm:px-6">
+                  {binary} → {decimal} / {decimal} → {binary}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
-    );
-  };
-  
+    </div>
+  );
+};


### PR DESCRIPTION
A tabela vinha de um boilerplate com três divs aninhadas em que a do meio aplicava `sm:-mx-6 lg:-mx-8` junto de `sm:px-6 lg:px-8`. A partir de 640px as margens negativas empurravam o conteúdo 24px (32px em `lg`) para fora do container arredondado, atravessando a moldura da sombra.

A classe `text-surface` não existe no Tailwind nem no `@theme` do projeto, então a cor de texto pretendida nunca era aplicada. `dark:border-white/10` mudava a cor das bordas conforme o tema do sistema num app sem tema escuro. O array de exemplos era recriado a cada render.

A tabela não tinha `<caption>` e a coluna `#` era um `<td>` comum, sem `scope="row"`, deixando as linhas sem cabeçalho para leitor de tela. O padding por célula passa a `px-3 sm:px-6`, reduzindo o quanto a tabela precisa rolar no celular.