### PR TITLE
fix: corrige idioma, favicon e carregamento da fonte

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,20 @@
 <!doctype html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/KWK.png" />
+    <link rel="icon" type="image/png" href="/KWK.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>KWK - Bin2Dec</title>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <meta
+      name="description"
+      content="Conversor de números entre binário e decimal, com validação de entrada e precisão sem limite de tamanho."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
 
 @theme {
-    --font-poppins: "Poppins", "sans-serif";
-  }
+  --font-poppins: "Poppins", ui-sans-serif, system-ui, sans-serif;
+}


### PR DESCRIPTION
O documento declarava `lang="en"` com todo o conteúdo em português, o que faz o leitor de tela pronunciar a página com fonética inglesa (WCAG 3.1.1).

O favicon declarava `type="image/svg+xml"` apontando para um PNG. A fonte era pedida sem `preconnect`, pagando DNS e dois handshakes TLS em série no caminho crítico. E a URL pedia os pesos `300;400;500;600;700`, mas o código só usa `font-light`, `font-normal` e `font-medium`: dois arquivos de fonte eram baixados sem nunca serem aplicados.

Em `@theme`, o fallback estava escrito como `"sans-serif"` entre aspas, o que o CSS interpreta como nome de família customizada e não como palavra-chave genérica, anulando o fallback.