### PR TITLE
chore: habilita o React Compiler e limpa as dependências

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,18 +7,20 @@ import tseslint from 'typescript-eslint'
 export default tseslint.config(
   { ignores: ['dist'] },
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommended,
+      reactHooks.configs.flat.recommended,
+    ],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
-      ecmaVersion: 2020,
+      ecmaVersion: 2022,
       globals: globals.browser,
     },
     plugins: {
-      'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
     },
     rules: {
-      ...reactHooks.configs.recommended.rules,
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },

--- a/package.json
+++ b/package.json
@@ -10,25 +10,23 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@tailwindcss/vite": "^4.0.5",
-    "autoprefixer": "^10.4.20",
-    "clsx": "^2.1.1",
-    "postcss": "^8.5.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",
+    "@tailwindcss/vite": "^4.3.3",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^4.3.4",
+    "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^9.19.0",
-    "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.4.18",
     "globals": "^15.14.0",
-    "tailwindcss": "^4.0.5",
+    "tailwindcss": "^4.3.3",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.22.0",
-    "vite": "^6.1.0"
+    "vite": "^6.4.3"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,11 @@ import tailwindcss from '@tailwindcss/vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
-    react(),
+    react({
+      babel: {
+        plugins: [['babel-plugin-react-compiler', { target: '19' }]],
+      },
+    }),
     tailwindcss(),
   ],
   build: {


### PR DESCRIPTION
Depende dos PRs #5 e #6: o `eslint-plugin-react-hooks` 7 traz as regras do compiler, e o `App.tsx` e o `notification.tsx` antigos eram acusados por `set-state-in-effect`.

**Compiler.** `babel-plugin-react-compiler` 1.0 entra no `@vitejs/plugin-react` com `target: 19`. Verificado no build **sem minificação** que a transformação de fato ocorre e não houve bail-out: `App()` abre com `c(41)` e o resultado derivado da conversão fica memoizado em `[mode, number]` sozinho, sem nenhum `useMemo` escrito à mão. Custo de 4,2 kB brutos (1,4 kB gzip), referente ao cache de memoização.

O `eslint-plugin-react-hooks` sobe de 5 para 7, que é a versão com o rule set do compiler: `set-state-in-effect`, `purity`, `immutability`, `refs`, `static-components`, `preserve-manual-memoization` entre outras. A config passa a estender `reactHooks.configs.flat.recommended`, que é a forma flat correta na v7, em vez de espalhar apenas `.rules` e registrar o plugin à mão.

**Dependências.** `clsx`, `autoprefixer` e `postcss` estavam declarados e não eram importados em lugar nenhum — os dois últimos não fazem sentido aqui, já que o Tailwind 4 via `@tailwindcss/vite` não usa pipeline PostCSS e faz o prefixo por conta própria. `@tailwindcss/vite` era a única dependência de build listada em `dependencies`. E o `vite` sobe de `^6.1.0` para `^6.4.3`, dentro do mesmo major, corrigindo os bypasses de `server.fs.deny` e o path traversal do rollup reportados no `npm audit`.

**Nenhum lockfile foi versionado.** O repositório tem `bun.lockb` e o bun 1.2 migraria para `bun.lock` (formato texto); escolher entre isso e padronizar no npm é decisão do projeto. Rode `bun install` antes do próximo build.