### PR TITLE
feat: dá volume 3D aos cards, com inclinação seguindo o ponteiro

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Footer } from "./components/footer";
 import { Navbar } from "./components/navbar";
 import { Table } from "./components/table";
 import { Notification } from "./components/notification";
+import { ConverterCard } from "./components/converter-card";
 
 type Mode = "decimal" | "binary";
 
@@ -95,22 +96,13 @@ function App() {
         <h1 className="sr-only">Conversor de binário e decimal</h1>
 
         <div className="flex w-full flex-col items-center justify-center gap-5 md:flex-row">
-          <div className="flex min-h-[7.5rem] w-full max-w-[15rem] flex-col items-center justify-center gap-y-1 rounded-xl bg-zinc-200 px-4 shadow-[var(--card-shadow)] drop-shadow-xl transition-[background-color,box-shadow] duration-300 dark:bg-zinc-900">
-            <label htmlFor="source-value" className="text-lg font-medium">
-              {sourceLabel}
-            </label>
-            <input
-              id="source-value"
-              className="w-full rounded-2xl border border-zinc-900 px-2 py-1 text-center outline-zinc-900 transition-colors duration-300 placeholder:text-zinc-500 dark:border-zinc-100 dark:outline-zinc-100 dark:placeholder:text-zinc-400"
-              value={number}
-              onChange={handleChange}
-              type="text"
-              inputMode="numeric"
-              autoComplete="off"
-              spellCheck={false}
-              placeholder={mode === "binary" ? "Ex.: 1010" : "Ex.: 10"}
-            />
-          </div>
+          <ConverterCard
+            id="source-value"
+            label={sourceLabel}
+            value={number}
+            onChange={handleChange}
+            placeholder={mode === "binary" ? "Ex.: 1010" : "Ex.: 10"}
+          />
 
           <button
             type="button"
@@ -120,21 +112,13 @@ function App() {
             Trocar
           </button>
 
-          <div
-            className="flex min-h-[7.5rem] w-full max-w-[15rem] flex-col items-center justify-center gap-y-1 rounded-xl bg-zinc-200 px-4 shadow-[var(--card-shadow)] drop-shadow-xl transition-[background-color,box-shadow] duration-300 dark:bg-zinc-900"
-            aria-live="polite"
-          >
-            <label htmlFor="result-value" className="text-lg font-medium">
-              {targetLabel}
-            </label>
-            <input
-              id="result-value"
-              className="w-full rounded-2xl border border-zinc-900 px-2 py-1 text-center transition-colors duration-300 dark:border-zinc-100"
-              value={result}
-              type="text"
-              readOnly
-            />
-          </div>
+          <ConverterCard
+            id="result-value"
+            label={targetLabel}
+            value={result}
+            readOnly
+            live
+          />
         </div>
         <Table />
       </main>

--- a/src/components/converter-card.tsx
+++ b/src/components/converter-card.tsx
@@ -1,0 +1,88 @@
+import { useRef, type ChangeEvent, type PointerEvent, type ReactNode } from "react";
+
+/** Angulo maximo de inclinacao, nas duas direcoes. */
+const MAX_TILT_DEG = 7;
+
+interface ConverterCardProps {
+  id: string;
+  label: string;
+  value: string;
+  placeholder?: string;
+  readOnly?: boolean;
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+  /** Faz o card anunciar mudancas de valor a leitores de tela. */
+  live?: boolean;
+  children?: ReactNode;
+}
+
+export const ConverterCard = ({
+  id,
+  label,
+  value,
+  placeholder,
+  readOnly = false,
+  onChange,
+  live = false,
+  children,
+}: ConverterCardProps) => {
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    const card = cardRef.current;
+    // Em toque nao ha ponteiro para acompanhar, e o CSS ja desliga o tilt.
+    if (!card || event.pointerType !== "mouse") return;
+
+    const rect = card.getBoundingClientRect();
+    const x = (event.clientX - rect.left) / rect.width;
+    const y = (event.clientY - rect.top) / rect.height;
+
+    // Escrita direta no style em vez de estado: a 60fps, um render do React
+    // por movimento do ponteiro seria descartado no frame seguinte.
+    card.style.setProperty("--tilt-x", `${(0.5 - y) * 2 * MAX_TILT_DEG}deg`);
+    card.style.setProperty("--tilt-y", `${(x - 0.5) * 2 * MAX_TILT_DEG}deg`);
+    card.style.setProperty("--glare-x", `${x * 100}%`);
+    card.style.setProperty("--glare-y", `${y * 100}%`);
+    card.style.setProperty("--glare-opacity", "1");
+    // Enquanto o ponteiro esta em cima, a transicao e curta o suficiente
+    // para suavizar sem dar sensacao de atraso.
+    card.style.setProperty("--tilt-ease", "90ms");
+  };
+
+  const handlePointerLeave = () => {
+    const card = cardRef.current;
+    if (!card) return;
+
+    // Na saida, volta devagar ao repouso.
+    card.style.setProperty("--tilt-ease", "450ms");
+    card.style.setProperty("--tilt-x", "0deg");
+    card.style.setProperty("--tilt-y", "0deg");
+    card.style.setProperty("--glare-opacity", "0");
+  };
+
+  return (
+    <div
+      ref={cardRef}
+      className="card-3d flex min-h-[7.5rem] w-full max-w-[15rem] flex-col items-center justify-center gap-y-1 rounded-xl bg-zinc-200 px-4 shadow-[var(--card-shadow)] dark:bg-zinc-900"
+      onPointerMove={handlePointerMove}
+      onPointerLeave={handlePointerLeave}
+      aria-live={live ? "polite" : undefined}
+    >
+      <label htmlFor={id} className="text-lg font-medium">
+        {label}
+      </label>
+      <input
+        id={id}
+        className="w-full rounded-2xl border border-zinc-900 px-2 py-1 text-center outline-zinc-900 transition-colors duration-300 placeholder:text-zinc-500 dark:border-zinc-100 dark:outline-zinc-100 dark:placeholder:text-zinc-400"
+        value={value}
+        onChange={onChange}
+        type="text"
+        inputMode="numeric"
+        autoComplete="off"
+        spellCheck={false}
+        placeholder={placeholder}
+        readOnly={readOnly}
+      />
+      {children}
+    </div>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -10,13 +10,100 @@
 
 /* O relevo dos cards e um box-shadow de valor arbitrario, que nenhuma
    variante dark: alcancaria de forma legivel. Mantendo as cores em
-   variaveis, a troca de tema atinge tambem as sombras. */
+   variaveis, a troca de tema atinge tambem o relevo.
+   --card-shadow e montado uma unica vez aqui: como .dark redefine as
+   pecas no mesmo elemento (o <html>), o valor composto se resolve com as
+   cores do tema ativo sem precisar ser reescrito. */
 :root {
   color-scheme: light;
-  --card-shadow: 6px 6px 26px #9b9b9d, -6px -6px 26px #ffffff;
+
+  --neu-dark: #9b9b9d;
+  --neu-light: #ffffff;
+  --card-edge-top: rgba(255, 255, 255, 0.85);
+  --card-edge-bottom: rgba(0, 0, 0, 0.1);
+  --card-drop: rgba(0, 0, 0, 0.35);
+  --card-glare: rgba(255, 255, 255, 0.55);
+
+  --card-shadow:
+    6px 6px 26px var(--neu-dark),
+    -6px -6px 26px var(--neu-light),
+    inset 0 1px 0 var(--card-edge-top),
+    inset 0 -2px 0 var(--card-edge-bottom),
+    0 12px 20px -14px var(--card-drop);
 }
 
 .dark {
   color-scheme: dark;
-  --card-shadow: 6px 6px 26px #09090b, -6px -6px 26px #303038;
+
+  --neu-dark: #09090b;
+  --neu-light: #303038;
+  --card-edge-top: rgba(255, 255, 255, 0.1);
+  --card-edge-bottom: rgba(0, 0, 0, 0.55);
+  --card-drop: rgba(0, 0, 0, 0.8);
+  --card-glare: rgba(255, 255, 255, 0.07);
+}
+
+@layer components {
+  /* Volume fixo pelas camadas de --card-shadow, mais inclinacao seguindo o
+     ponteiro. Os angulos e a posicao do brilho chegam como variaveis,
+     escritas direto no style pelo handler: um setState por movimento do
+     ponteiro seria descartado no frame seguinte. */
+  .card-3d {
+    position: relative;
+    --tilt-x: 0deg;
+    --tilt-y: 0deg;
+    --tilt-ease: 450ms;
+    --glare-x: 50%;
+    --glare-y: 50%;
+    --glare-opacity: 0;
+
+    transform: perspective(900px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y));
+    transform-style: preserve-3d;
+    transition:
+      transform var(--tilt-ease) cubic-bezier(0.22, 1, 0.36, 1),
+      box-shadow 300ms ease-out,
+      background-color 300ms ease-out;
+  }
+
+  .card-3d::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    opacity: var(--glare-opacity);
+    background: radial-gradient(
+      16rem circle at var(--glare-x) var(--glare-y),
+      var(--card-glare),
+      transparent 65%
+    );
+    transition: opacity 300ms ease-out;
+  }
+
+  /* O conteudo flutua sobre a face do card. O deslocamento e pequeno de
+     proposito: com perspective de 900px, 12px ja da o paralaxe sem
+     ampliar o texto o suficiente para borrar. */
+  .card-3d > * {
+    transform: translateZ(0.75rem);
+  }
+
+  /* Em toque nao existe ponteiro para acompanhar; fica so o volume fixo. */
+  @media (hover: none), (pointer: coarse) {
+    .card-3d,
+    .card-3d > * {
+      transform: none;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .card-3d,
+    .card-3d > * {
+      transform: none;
+    }
+
+    .card-3d,
+    .card-3d::after {
+      transition: none;
+    }
+  }
 }


### PR DESCRIPTION
Duas camadas de efeito, conforme combinado.

**Volume fixo.** `--card-shadow` deixa de ser apenas o par de sombras neumórficas e passa a compor cinco camadas: as duas sombras externas, uma borda de luz no topo (`inset 0 1px`), uma aresta escura embaixo (`inset 0 -2px`) e uma sombra de contato projetada. As peças ficam em variáveis por tema, então o relevo continua correto no escuro, onde a luz vem de cima com muito menos intensidade. Vale também para a tabela, que usa a mesma variável.

**Inclinação.** O card recebe `perspective(900px)` com `rotateX`/`rotateY` vindos de variáveis CSS, e o handler de `pointermove` escreve esses ângulos direto no `style` do elemento. Não há estado de React envolvido de propósito: a 60fps um render por movimento do ponteiro seria descartado no frame seguinte. Um brilho radial acompanha a posição do cursor pelo `::after`.

Detalhes que o efeito exigiu:

- `drop-shadow-xl` saiu dos cards. Ele é um `filter`, e `filter` transforma o elemento em containing block e achata o contexto 3D, o que anularia o `translateZ` do conteúdo. Verificado no navegador que `filter` agora é `none` e `transform-style` permanece `preserve-3d`.
- O conteúdo sobe 12px em Z para dar paralaxe. O valor é pequeno de propósito: com 900px de perspectiva a ampliação fica em 1,4%, abaixo do que borraria o texto do input.
- A transição do `transform` é de 90ms enquanto o ponteiro está sobre o card, o que suaviza sem dar sensação de atraso, e de 450ms na saída.
- Em `pointerType` diferente de `mouse` o handler retorna sem fazer nada, e as media queries `(hover: none)`/`(pointer: coarse)` zeram o `transform`: em toque sobra o volume fixo, que é o que faz sentido sem cursor.
- `prefers-reduced-motion` desliga inclinação e transições.

Os dois cards eram markup duplicado em `App.tsx`, diferindo apenas em rótulo, valor e `readOnly`. Viraram o componente `ConverterCard`, que é também onde o tilt fica encapsulado.

Verificado no navegador: no canto superior direito a matriz de `transform` traz rotação real, no centro volta à identidade, e a saída do ponteiro zera os ângulos e o brilho.