### PR TITLE
feat: painel expansível com o resultado inteiro e o cálculo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,45 +4,36 @@ import { Navbar } from "./components/navbar";
 import { Table } from "./components/table";
 import { Notification } from "./components/notification";
 import { ConverterCard } from "./components/converter-card";
-
-type Mode = "decimal" | "binary";
+import { ResultDetails } from "./components/result-details";
+import {
+  convert,
+  INPUT_RULES,
+  RESULT_VISIBLE_CHARS,
+  type Mode,
+} from "./lib/conversion";
 
 const NOTIFICATION_TIMEOUT_MS = 3000;
 
 /** Evita travar a UI se colarem uma entrada absurdamente longa. */
 const MAX_INPUT_LENGTH = 1024;
 
-const INPUT_RULES: Record<Mode, { pattern: RegExp; warning: string }> = {
-  decimal: { pattern: /^\d*$/, warning: "Apenas números" },
-  binary: { pattern: /^[01]*$/, warning: "Apenas 0 e 1" },
-};
-
-/**
- * Converte com BigInt para não perder precisão acima de
- * Number.MAX_SAFE_INTEGER nem estourar para Infinity em entradas longas.
- */
-function convert(value: string, mode: Mode): string {
-  if (value === "") return "";
-
-  try {
-    return mode === "binary"
-      ? BigInt(`0b${value}`).toString(10)
-      : BigInt(value).toString(2);
-  } catch {
-    return "Inválido";
-  }
-}
-
 function App() {
   const [number, setNumber] = useState("");
   const [mode, setMode] = useState<Mode>("decimal");
   const [warning, setWarning] = useState("");
+  const [detailsOpen, setDetailsOpen] = useState(false);
   const warningTimeout = useRef<number | null>(null);
 
   // O resultado é derivado da entrada: sem estado espelhado nem efeito.
   const result = convert(number, mode);
   const sourceLabel = mode === "binary" ? "Binário" : "Decimal";
   const targetLabel = mode === "binary" ? "Decimal" : "Binário";
+
+  // O painel só é oferecido quando o resultado deixa de caber no input, e
+  // some sozinho quando volta a caber: derivar evita um efeito para fechá-lo.
+  const resultIsBinary = mode === "decimal";
+  const canExpand =
+    result !== "" && result !== "Inválido" && result.length > RESULT_VISIBLE_CHARS;
 
   useEffect(() => {
     return () => {
@@ -120,6 +111,19 @@ function App() {
             live
           />
         </div>
+
+        {canExpand && (
+          <ResultDetails
+            open={detailsOpen}
+            onToggle={() => setDetailsOpen((previous) => !previous)}
+            binary={resultIsBinary ? result : number}
+            decimal={resultIsBinary ? number : result}
+            result={result}
+            resultIsBinary={resultIsBinary}
+            label={targetLabel}
+          />
+        )}
+
         <Table />
       </main>
       <Footer />

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,5 +1,29 @@
 import type { IconSvgProps } from "../types";
 
+export const ChevronDownIcon = ({
+  size = 20,
+  width,
+  height,
+  ...props
+}: IconSvgProps) => (
+  <svg
+    aria-hidden="true"
+    fill="none"
+    height={height ?? size}
+    viewBox="0 0 24 24"
+    width={width ?? size}
+    {...props}
+  >
+    <path
+      d="M6 9l6 6 6-6"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+    />
+  </svg>
+);
+
 export const MoonFilledIcon = ({
   size = 24,
   width,

--- a/src/components/result-details.tsx
+++ b/src/components/result-details.tsx
@@ -1,0 +1,91 @@
+import { ChevronDownIcon } from "./icons";
+import { buildExpansion, groupDigits } from "../lib/conversion";
+
+interface ResultDetailsProps {
+  open: boolean;
+  onToggle: () => void;
+  /** Forma binaria do valor, seja ela a entrada ou o resultado. */
+  binary: string;
+  /** Forma decimal do valor, seja ela a entrada ou o resultado. */
+  decimal: string;
+  /** O resultado exibido no card, que e o que nao caberia no input. */
+  result: string;
+  resultIsBinary: boolean;
+  label: string;
+}
+
+export const ResultDetails = ({
+  open,
+  onToggle,
+  binary,
+  decimal,
+  result,
+  resultIsBinary,
+  label,
+}: ResultDetailsProps) => {
+  const expansion = buildExpansion(binary);
+  const unit = resultIsBinary ? "bits" : "dígitos";
+
+  return (
+    <section className="w-full max-w-[585px]">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        aria-controls="result-details"
+        className="mx-auto flex items-center gap-x-1.5 rounded-lg px-3 py-1.5 text-sm font-medium text-zinc-700 transition-colors duration-300 hover:bg-zinc-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:focus-visible:outline-zinc-100"
+      >
+        {open ? "Ocultar cálculo completo" : "Ver cálculo completo"}
+        <ChevronDownIcon
+          className={`transition-transform duration-300 ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {/* 0fr -> 1fr anima a abertura sem precisar saber a altura do conteudo. */}
+      <div
+        id="result-details"
+        data-open={open}
+        className="grid grid-rows-[0fr] transition-[grid-template-rows] duration-300 ease-out data-[open=true]:grid-rows-[1fr]"
+      >
+        <div className="overflow-hidden">
+          <div className="mt-3 flex flex-col gap-y-4 rounded-xl bg-zinc-200 p-4 text-sm shadow-[var(--card-shadow)] transition-[background-color,box-shadow] duration-300 dark:bg-zinc-900">
+            <div>
+              <h2 className="font-medium">
+                {label} completo · {result.length} {unit}
+              </h2>
+              <p className="mt-1 font-mono break-all text-zinc-700 dark:text-zinc-300">
+                {groupDigits(result, resultIsBinary ? 4 : 3)}
+              </p>
+            </div>
+
+            <div>
+              <h2 className="font-medium">
+                Cálculo · soma das potências de 2 dos bits ligados
+              </h2>
+              <div className="mt-1 flex flex-col gap-y-0.5 font-mono break-words text-zinc-700 dark:text-zinc-300">
+                <p>
+                  {expansion.terms.map((term, index) => (
+                    <span key={term.exponent}>
+                      {index > 0 && " + "}2<sup>{term.exponent}</sup>
+                    </span>
+                  ))}
+                  {expansion.omittedTerms > 0 &&
+                    ` + … (${expansion.omittedTerms} de ${expansion.totalTerms} termos omitidos)`}
+                </p>
+
+                {expansion.showValues && (
+                  <p>
+                    = {expansion.terms.map((term) => term.value).join(" + ")}
+                    {expansion.omittedTerms > 0 && " + …"}
+                  </p>
+                )}
+
+                <p>= {decimal} em decimal</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/lib/conversion.ts
+++ b/src/lib/conversion.ts
@@ -1,0 +1,88 @@
+export type Mode = "decimal" | "binary";
+
+export const INPUT_RULES: Record<Mode, { pattern: RegExp; warning: string }> = {
+  decimal: { pattern: /^\d*$/, warning: "Apenas números" },
+  binary: { pattern: /^[01]*$/, warning: "Apenas 0 e 1" },
+};
+
+/** Acima disso o resultado nao cabe mais no input e vale oferecer o painel. */
+export const RESULT_VISIBLE_CHARS = 20;
+
+/** Termos da expansao exibidos antes de resumir o restante. */
+export const MAX_EXPANSION_TERMS = 12;
+
+/**
+ * Ate esse expoente os valores das potencias ainda sao curtos o bastante
+ * para caberem numa linha. Acima, so a linha de expoentes e mostrada.
+ */
+const MAX_VALUE_EXPONENT = 31;
+
+/**
+ * Converte com BigInt para nao perder precisao acima de
+ * Number.MAX_SAFE_INTEGER nem estourar para Infinity em entradas longas.
+ */
+export function convert(value: string, mode: Mode): string {
+  if (value === "") return "";
+
+  try {
+    return mode === "binary"
+      ? BigInt(`0b${value}`).toString(10)
+      : BigInt(value).toString(2);
+  } catch {
+    return "Inválido";
+  }
+}
+
+/** Agrupa a partir da direita, para leitura de numeros longos. */
+export function groupDigits(value: string, size: number): string {
+  const groups: string[] = [];
+
+  for (let end = value.length; end > 0; end -= size) {
+    groups.unshift(value.slice(Math.max(0, end - size), end));
+  }
+
+  return groups.join(" ");
+}
+
+export interface ExpansionTerm {
+  exponent: number;
+  value: string;
+}
+
+export interface Expansion {
+  terms: ExpansionTerm[];
+  totalTerms: number;
+  omittedTerms: number;
+  showValues: boolean;
+}
+
+/**
+ * A conversao nos dois sentidos e a mesma soma: cada bit ligado contribui
+ * com 2 elevado a sua posicao. Um unico painel explica decimal -> binario e
+ * binario -> decimal.
+ */
+export function buildExpansion(
+  binary: string,
+  maxTerms = MAX_EXPANSION_TERMS,
+): Expansion {
+  const highestExponent = binary.length - 1;
+  const terms: ExpansionTerm[] = [];
+  let totalTerms = 0;
+
+  for (let index = 0; index < binary.length; index++) {
+    if (binary[index] !== "1") continue;
+
+    totalTerms++;
+    if (terms.length >= maxTerms) continue;
+
+    const exponent = highestExponent - index;
+    terms.push({ exponent, value: (1n << BigInt(exponent)).toString(10) });
+  }
+
+  return {
+    terms,
+    totalTerms,
+    omittedTerms: totalTerms - terms.length,
+    showValues: highestExponent <= MAX_VALUE_EXPONENT,
+  };
+}


### PR DESCRIPTION
Quando o resultado passa de 20 caracteres ele deixa de caber no input do card, que tem largura fixa de 15rem, e o valor só pode ser lido rolando o campo. Nesses casos aparece o botão "Ver cálculo completo", que abre um painel com:

- o resultado inteiro, quebrando linha e agrupado para leitura: de 4 em 4 quando é binário, de 3 em 3 quando é decimal, com a contagem de bits ou dígitos;
- a expansão posicional, que é a mesma nos dois sentidos, já que converter binário é somar 2 elevado à posição de cada bit ligado. Um único painel explica decimal → binário e binário → decimal.

Limites, porque os dois lados crescem rápido:

- a expansão mostra no máximo 12 termos e resume o resto como `(52 de 64 termos omitidos)`, em vez de despejar 1024 parcelas;
- a linha com os valores das potências só aparece até o expoente 31. Acima disso cada parcela passa de 10 dígitos e a linha deixa de ser legível, então fica só a de expoentes mais o total em decimal.

O botão aparece por derivação de `result.length`, não por estado: quando o resultado volta a caber, o painel desaparece sozinho, sem efeito para fechá-lo. A animação usa `grid-template-rows` de `0fr` para `1fr`, que dispensa saber a altura do conteúdo de antemão, e o botão carrega `aria-expanded` e `aria-controls` apontando para o painel.

A lógica de conversão saiu de `App.tsx` para `src/lib/conversion.ts`, junto do agrupamento de dígitos e da montagem da expansão, que são do mesmo domínio.

Verificado no navegador: `1010` não oferece o painel, 21 bits oferecem, 64 bits omitem a linha de valores e informam os termos omitidos, e ao encurtar a entrada o painel sai da tela.