### PR TITLE
feat: adiciona placeholder no campo de resultado

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -111,6 +111,7 @@ function App() {
             id="result-value"
             label={targetLabel}
             value={result}
+            placeholder="Resultado"
             readOnly
             live
           />


### PR DESCRIPTION
O campo de saída ficava simplesmente vazio antes da primeira conversão e sempre que a entrada era apagada, sem indicar que ali sai algo. Passa a exibir "Resultado" como placeholder.

Aproveita o estilo que o `ConverterCard` já aplicava ao campo de entrada, em `zinc-500` no claro e `zinc-400` no escuro, tom que se distingue do valor real e não sugere conteúdo editável num campo `readOnly`.