### PR TITLE
feat: cria logo, troca a tipografia e assume o nome Bin2Dec by KWK

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/KWK.png" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>KWK - Bin2Dec</title>
+    <title>Bin2Dec by KWK</title>
     <meta
       name="description"
       content="Conversor de números entre binário e decimal, com validação de entrada e precisão sem limite de tamanho."
@@ -14,7 +14,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=JetBrains+Mono:wght@400&display=swap"
       rel="stylesheet"
     />
     <script>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <style>
+    .bg { fill: #18181b }
+    .fg { stroke: #e4e4e7 }
+    .dot { fill: #e4e4e7 }
+    @media (prefers-color-scheme: light) {
+      .bg { fill: #e4e4e7 }
+      .fg { stroke: #18181b }
+      .dot { fill: #18181b }
+    }
+  </style>
+  <rect class="bg" width="32" height="32" rx="7" />
+  <path
+    class="fg"
+    d="M10 22 L22 10"
+    fill="none"
+    stroke-width="4.2"
+    stroke-linecap="round"
+  />
+  <circle class="dot" cx="10" cy="10" r="2.4" />
+  <circle class="dot" cx="22" cy="22" r="2.4" />
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,7 +84,7 @@ function App() {
     <>
       <Navbar />
       <Notification text={warning} active={warning !== ""} />
-      <main className="flex min-h-screen w-full flex-col items-center justify-center gap-y-10 bg-zinc-200 px-4 pt-20 pb-28 font-poppins transition-colors duration-300 sm:px-6 md:pb-24 lg:px-8 dark:bg-zinc-900 dark:text-zinc-100">
+      <main className="flex min-h-screen w-full flex-col items-center justify-center gap-y-10 bg-zinc-200 px-4 pt-20 pb-28 transition-colors duration-300 sm:px-6 md:pb-24 lg:px-8 dark:bg-zinc-900 dark:text-zinc-100">
         <h1 className="sr-only">Conversor de binário e decimal</h1>
 
         <div className="flex w-full flex-col items-center justify-center gap-5 md:flex-row">

--- a/src/components/converter-card.tsx
+++ b/src/components/converter-card.tsx
@@ -72,7 +72,7 @@ export const ConverterCard = ({
       </label>
       <input
         id={id}
-        className="w-full rounded-2xl border border-zinc-900 px-2 py-1 text-center outline-zinc-900 transition-colors duration-300 placeholder:text-zinc-500 dark:border-zinc-100 dark:outline-zinc-100 dark:placeholder:text-zinc-400"
+        className="w-full rounded-2xl border border-zinc-900 px-2 py-1 text-center font-mono transition-colors duration-300 outline-zinc-900 placeholder:font-sans placeholder:text-zinc-500 dark:border-zinc-100 dark:outline-zinc-100 dark:placeholder:text-zinc-400"
         value={value}
         onChange={onChange}
         type="text"

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -23,7 +23,7 @@ const SOCIAL_LINKS = [
 
 export const Footer = () => {
   return (
-    <footer className="fixed bottom-0 z-50 flex w-full items-center justify-center border-t border-zinc-950/10 bg-zinc-200 py-2 text-center font-poppins shadow-[0px_-3px_12px_-8px_rgba(0,_0,_0,_1)] transition-colors duration-300 dark:border-white/10 dark:bg-zinc-900 dark:text-zinc-100">
+    <footer className="fixed bottom-0 z-50 flex w-full items-center justify-center border-t border-zinc-950/10 bg-zinc-200 py-2 text-center shadow-[0px_-3px_12px_-8px_rgba(0,_0,_0,_1)] transition-colors duration-300 dark:border-white/10 dark:bg-zinc-900 dark:text-zinc-100">
       <div className="mx-auto flex w-full max-w-[1024px] flex-col items-center justify-between gap-y-1 px-4 sm:px-6 md:flex-row">
         <p className="font-medium">
           © {CURRENT_YEAR} Kohako.dev, Inc. All rights reserved.

--- a/src/components/links.tsx
+++ b/src/components/links.tsx
@@ -1,7 +1,7 @@
 export type SiteConfig = typeof siteConfig;
 
 export const siteConfig = {
-  name: "KWK - Bin2Dec",
+  name: "Bin2Dec by KWK",
   links: {
     github: "https://github.com/dev-kohako",
     youtube: "https://www.youtube.com/@dev_kohako",

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -1,0 +1,28 @@
+import type { IconSvgProps } from "../types";
+
+/**
+ * Segue a linguagem da marca KWK: barras diagonais grossas de pontas
+ * arredondadas em grade de 45 graus. Aqui a diagonal e o eixo da conversao e
+ * os dois pontos nas quinas opostas sao as duas bases numericas.
+ * Sem texto, então não depende de fonte, e todo em currentColor, então
+ * acompanha o tema sem variante dark:.
+ */
+export const Logo = ({ size = 20, width, height, ...props }: IconSvgProps) => (
+  <svg
+    aria-hidden="true"
+    fill="none"
+    height={height ?? size}
+    viewBox="0 0 32 32"
+    width={width ?? size}
+    {...props}
+  >
+    <path
+      d="M9.5 22.5 L22.5 9.5"
+      stroke="currentColor"
+      strokeWidth="4.5"
+      strokeLinecap="round"
+    />
+    <circle cx="9.5" cy="9.5" r="2.6" fill="currentColor" />
+    <circle cx="22.5" cy="22.5" r="2.6" fill="currentColor" />
+  </svg>
+);

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,4 +1,6 @@
 import { Moon, Sun } from "lucide-react";
+import { Logo } from "./logo";
+import { siteConfig } from "./links";
 import { useTheme } from "../hooks/use-theme";
 
 export const Navbar = () => {
@@ -6,32 +8,38 @@ export const Navbar = () => {
   const isDark = theme === "dark";
 
   return (
-    <header className="fixed top-0 z-50 flex w-full items-center justify-center border-b border-zinc-950/10 bg-zinc-200 py-2 text-center font-poppins shadow-[0px_3px_12px_-8px_rgba(0,_0,_0,_1)] transition-colors duration-300 dark:border-white/10 dark:bg-zinc-900 dark:text-zinc-100">
+    <header className="fixed top-0 z-50 flex w-full items-center justify-center border-b border-zinc-950/10 bg-zinc-200 py-2 text-center shadow-[0px_3px_12px_-8px_rgba(0,_0,_0,_1)] transition-colors duration-300 dark:border-white/10 dark:bg-zinc-900 dark:text-zinc-100">
       <nav className="mx-auto flex w-full max-w-[1024px] items-center justify-between px-4 sm:px-6">
-        <a
-          href="/"
-          className="flex items-center gap-x-1 rounded font-medium focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-900 dark:focus-visible:outline-zinc-100"
-        >
-          <img
-            className="mb-0.5 w-3 object-contain invert dark:invert-0"
-            src="/KWK.png"
-            alt=""
-          />
-          KWK
-        </a>
-
-        <div className="flex items-center gap-x-3">
-          <p className="font-medium">Bin2Dec</p>
-          <button
-            type="button"
-            onClick={toggleTheme}
-            aria-label={isDark ? "Ativar tema claro" : "Ativar tema escuro"}
-            aria-pressed={isDark}
-            className="rounded-lg border border-zinc-950/10 p-1.5 text-zinc-800 transition-colors duration-300 hover:bg-zinc-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-900 dark:border-white/10 dark:text-zinc-200 dark:hover:bg-zinc-800 dark:focus-visible:outline-zinc-100"
+        {/* items-center e não items-baseline: a baseline de um flex container
+            vem do primeiro item, que aqui é o SVG, e a baseline de um SVG é a
+            borda de baixo. Isso desalinhava "Bin2Dec" de "by KWK". */}
+        <div className="flex items-center gap-x-1.5">
+          <a
+            href="/"
+            className="flex items-center gap-x-1.5 rounded leading-none font-medium focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-900 dark:focus-visible:outline-zinc-100"
           >
-            {isDark ? <Sun size={18} /> : <Moon size={18} />}
-          </button>
+            <Logo size={20} className="shrink-0" />
+            Bin2Dec
+          </a>
+          <a
+            href={siteConfig.links.github}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded text-sm leading-none text-zinc-600 transition-colors duration-300 hover:text-zinc-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 dark:focus-visible:outline-zinc-100"
+          >
+            by KWK
+          </a>
         </div>
+
+        <button
+          type="button"
+          onClick={toggleTheme}
+          aria-label={isDark ? "Ativar tema claro" : "Ativar tema escuro"}
+          aria-pressed={isDark}
+          className="rounded-lg border border-zinc-950/10 p-1.5 text-zinc-800 transition-colors duration-300 hover:bg-zinc-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-900 dark:border-white/10 dark:text-zinc-200 dark:hover:bg-zinc-800 dark:focus-visible:outline-zinc-100"
+        >
+          {isDark ? <Sun size={18} /> : <Moon size={18} />}
+        </button>
       </nav>
     </header>
   );

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -42,9 +42,13 @@ export const Table = () => {
                 >
                   {id}
                 </th>
-                <td className="px-3 py-4 whitespace-nowrap sm:px-6">{binary}</td>
-                <td className="px-3 py-4 whitespace-nowrap sm:px-6">{decimal}</td>
-                <td className="px-3 py-4 whitespace-nowrap sm:px-6">
+                <td className="px-3 py-4 font-mono whitespace-nowrap sm:px-6">
+                  {binary}
+                </td>
+                <td className="px-3 py-4 font-mono whitespace-nowrap sm:px-6">
+                  {decimal}
+                </td>
+                <td className="px-3 py-4 font-mono whitespace-nowrap sm:px-6">
                   {binary} → {decimal} / {decimal} → {binary}
                 </td>
               </tr>

--- a/src/index.css
+++ b/src/index.css
@@ -4,8 +4,13 @@
    para que o botao da navbar possa sobrepor a preferencia do sistema. */
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* Sobrescrever --font-sans troca a fonte de todo o app: o Tailwind 4 deriva
+   --default-font-family dela, então não é preciso uma classe por elemento.
+   O mono não é decorativo aqui: em binário longo, largura fixa por dígito é
+   o que deixa os bits alinhados e contáveis. */
 @theme {
-  --font-poppins: "Poppins", ui-sans-serif, system-ui, sans-serif;
+  --font-sans: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 /* O relevo dos cards e um box-shadow de valor arbitrario, que nenhuma


### PR DESCRIPTION
**Logo.** Segue a linguagem da marca KWK, que é feita de barras diagonais grossas de pontas arredondadas em grade de 45°: aqui a diagonal é o eixo da conversão e os dois pontos nas quinas opostas são as duas bases numéricas. Sem texto, então não depende de fonte carregada nem de conversão para path, e todo em `currentColor`, então acompanha o tema sem variante `dark:`. Verificado que o stroke resolve exatamente para a cor do texto do header nos dois temas.

**Favicon.** SVG de menos de 600 bytes com o mesmo desenho, com fundo arredondado para destacar na aba e `prefers-color-scheme` para inverter no escuro. Substitui o `KWK.png`, que tinha **318 kB**, servia de favicon e era renderizado a 12px na navbar — mais de quatro vezes o peso do bundle inteiro para um logo de 12 pixels. O arquivo continua em `public/`, agora sem nenhuma referência; apagar ou não é decisão de quem cuida da marca.

**Tipografia.** Poppins dá lugar a **Space Grotesk** na interface e **JetBrains Mono** nos números. O mono não é escolha estética: em binário longo, largura fixa por dígito é o que deixa os bits alinhados e contáveis, o que importa justamente num conversor. Aplicado nos dois campos, nas células de binário e decimal da tabela e no painel de cálculo.

A troca foi feita sobrescrevendo `--font-sans` e `--font-mono` no `@theme`, e não criando uma classe por elemento: o Tailwind 4 deriva `--default-font-family` de `--font-sans`, confirmado no CSS gerado. As três ocorrências de `font-poppins` saíram do markup e o CSS caiu de 19,66 kB para 18,06 kB. Pedidos apenas os pesos em uso.

**Nome e alinhamento.** A navbar deixa de mostrar "KWK" e "Bin2Dec" em pontas opostas e passa a trazer logo, "Bin2Dec" e "by KWK" juntos, com o crédito linkando para o perfil. Mantido o nome Bin2Dec, que é o do repositório.

O grupo da marca usa `items-center`, e não `items-baseline`: a baseline de um flex container vem do seu primeiro item, que aqui é o SVG, e a baseline de um SVG é a sua borda de baixo — era isso que desalinhava "Bin2Dec" de "by KWK". Medido depois da correção: centro vertical do logo em 24,0, de "Bin2Dec" em 23,5 e de "by KWK" em 24,0.