### PR TITLE
fix: dá aresta ao tema claro e reduz o rodapé

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -11,7 +11,7 @@ import { siteConfig } from "./links";
 // pureza que o React Compiler exige.
 const CURRENT_YEAR = new Date().getFullYear();
 
-const ICON_SIZE = 20;
+const ICON_SIZE = 16;
 
 const SOCIAL_LINKS = [
   { label: "GitHub", href: siteConfig.links.github, Icon: SiGithub },
@@ -25,10 +25,10 @@ export const Footer = () => {
   return (
     <footer className="fixed bottom-0 z-50 flex w-full items-center justify-center border-t border-zinc-950/10 bg-zinc-200 py-2 text-center shadow-[0px_-3px_12px_-8px_rgba(0,_0,_0,_1)] transition-colors duration-300 dark:border-white/10 dark:bg-zinc-900 dark:text-zinc-100">
       <div className="mx-auto flex w-full max-w-[1024px] flex-col items-center justify-between gap-y-1 px-4 sm:px-6 md:flex-row">
-        <p className="font-medium">
+        <p className="text-xs text-zinc-600 sm:text-sm dark:text-zinc-400">
           © {CURRENT_YEAR} Kohako.dev, Inc. All rights reserved.
         </p>
-        <ul className="flex items-center justify-center gap-x-2">
+        <ul className="flex items-center justify-center gap-x-3">
           {SOCIAL_LINKS.map(({ label, href, Icon }) => (
             <li key={label}>
               <a

--- a/src/index.css
+++ b/src/index.css
@@ -22,19 +22,27 @@
 :root {
   color-scheme: light;
 
-  --neu-dark: #9b9b9d;
+  /* No claro o relevo dependia de #ffffff sobre um fundo #e4e4e7, diferença
+     de luminância pequena demais para desenhar uma aresta. O que resolve não
+     é escurecer a sombra difusa, é dar contorno: --card-ring traça uma
+     hairline e --card-contact uma sombra curta logo abaixo da borda. No
+     escuro o mesmo par existe com sinal invertido. */
+  --neu-dark: rgba(113, 113, 122, 0.5);
   --neu-light: #ffffff;
-  --card-edge-top: rgba(255, 255, 255, 0.85);
-  --card-edge-bottom: rgba(0, 0, 0, 0.1);
-  --card-drop: rgba(0, 0, 0, 0.35);
+  --card-ring: rgba(24, 24, 27, 0.12);
+  --card-edge-top: rgba(255, 255, 255, 0.9);
+  --card-edge-bottom: rgba(24, 24, 27, 0.07);
+  --card-contact: rgba(24, 24, 27, 0.16);
   --card-glare: rgba(255, 255, 255, 0.55);
 
   --card-shadow:
-    6px 6px 26px var(--neu-dark),
-    -6px -6px 26px var(--neu-light),
+    inset 0 0 0 1px var(--card-ring),
     inset 0 1px 0 var(--card-edge-top),
-    inset 0 -2px 0 var(--card-edge-bottom),
-    0 12px 20px -14px var(--card-drop);
+    inset 0 -1px 0 var(--card-edge-bottom),
+    0 1px 2px var(--card-contact),
+    0 10px 22px -12px var(--card-contact),
+    8px 8px 24px var(--neu-dark),
+    -8px -8px 24px var(--neu-light);
 }
 
 .dark {
@@ -42,9 +50,10 @@
 
   --neu-dark: #09090b;
   --neu-light: #303038;
+  --card-ring: rgba(255, 255, 255, 0.07);
   --card-edge-top: rgba(255, 255, 255, 0.1);
   --card-edge-bottom: rgba(0, 0, 0, 0.55);
-  --card-drop: rgba(0, 0, 0, 0.8);
+  --card-contact: rgba(0, 0, 0, 0.65);
   --card-glare: rgba(255, 255, 255, 0.07);
 }
 


### PR DESCRIPTION
**Tema claro.** O relevo dos cards dependia de um brilho `#ffffff` contra um fundo `#e4e4e7`: diferença de luminância pequena demais para desenhar uma borda, o que fazia a superfície parecer branco chapado. No escuro o mesmo desenho funciona porque `#09090b` contra `#18181b` tem contraste relativo bem maior.

O que resolve não é escurecer a sombra difusa, que já era escura e apenas espalhada em 26px de blur, e sim **dar contorno**. Duas peças novas no `--card-shadow`, ambas com equivalente invertido no escuro:

| peça | efeito | medição no claro |
|---|---|---|
| `--card-ring` | hairline inset de 1px | compõe para `rgb(204,204,207)`, **1,26:1** contra a superfície |
| `--card-contact` | sombra curta de 1px sob a borda + contato projetado | assenta o card no fundo |

O número de referência: a borda das linhas da tabela (`border-zinc-950/10`) dá **1,24:1** e já era legível no tema claro, então o anel novo é um pouco mais forte que algo que comprovadamente aparece. A sombra difusa passou de 6px/26px para 8px/24px e o lado escuro virou `rgba` de `zinc-500`, que compõe melhor sobre o fundo do que o hex fixo. Verificado que as sete camadas chegam ao `box-shadow` computado.

**Rodapé.** Os créditos estavam em 16px com `font-medium`, mais pesados que o próprio conteúdo da página, e os ícones em 20px. Passam a 14px em tom atenuado (12px abaixo de `sm`) e 16px, com o espaçamento entre ícones subindo de 8px para 12px para compensar. A altura do rodapé caiu para 41px.