### PR TITLE
fix: reforça o relevo no claro, casa as larguras e leva o 3D à tabela

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,7 +87,10 @@ function App() {
       <main className="flex min-h-screen w-full flex-col items-center justify-center gap-y-10 bg-zinc-200 px-4 pt-20 pb-28 transition-colors duration-300 sm:px-6 md:pb-24 lg:px-8 dark:bg-zinc-900 dark:text-zinc-100">
         <h1 className="sr-only">Conversor de binário e decimal</h1>
 
-        <div className="flex w-full flex-col items-center justify-center gap-5 md:flex-row">
+        {/* Grade em vez de flex: as duas colunas 1fr dividem o que sobra
+            depois do botão, então a linha ocupa exatamente --content-max, a
+            mesma largura da tabela, em vez de resultar da soma dos filhos. */}
+        <div className="grid w-full max-w-[var(--content-max)] grid-cols-1 justify-items-center gap-5 md:grid-cols-[1fr_auto_1fr] md:items-center">
           <ConverterCard
             id="source-value"
             label={sourceLabel}

--- a/src/components/converter-card.tsx
+++ b/src/components/converter-card.tsx
@@ -1,7 +1,5 @@
-import { useRef, type ChangeEvent, type PointerEvent, type ReactNode } from "react";
-
-/** Angulo maximo de inclinacao, nas duas direcoes. */
-const MAX_TILT_DEG = 7;
+import type { ChangeEvent, ReactNode } from "react";
+import { useTilt } from "../hooks/use-tilt";
 
 interface ConverterCardProps {
   id: string;
@@ -10,7 +8,7 @@ interface ConverterCardProps {
   placeholder?: string;
   readOnly?: boolean;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
-  /** Faz o card anunciar mudancas de valor a leitores de tela. */
+  /** Faz o card anunciar mudanças de valor a leitores de tela. */
   live?: boolean;
   children?: ReactNode;
 }
@@ -25,46 +23,14 @@ export const ConverterCard = ({
   live = false,
   children,
 }: ConverterCardProps) => {
-  const cardRef = useRef<HTMLDivElement>(null);
-
-  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
-    const card = cardRef.current;
-    // Em toque nao ha ponteiro para acompanhar, e o CSS ja desliga o tilt.
-    if (!card || event.pointerType !== "mouse") return;
-
-    const rect = card.getBoundingClientRect();
-    const x = (event.clientX - rect.left) / rect.width;
-    const y = (event.clientY - rect.top) / rect.height;
-
-    // Escrita direta no style em vez de estado: a 60fps, um render do React
-    // por movimento do ponteiro seria descartado no frame seguinte.
-    card.style.setProperty("--tilt-x", `${(0.5 - y) * 2 * MAX_TILT_DEG}deg`);
-    card.style.setProperty("--tilt-y", `${(x - 0.5) * 2 * MAX_TILT_DEG}deg`);
-    card.style.setProperty("--glare-x", `${x * 100}%`);
-    card.style.setProperty("--glare-y", `${y * 100}%`);
-    card.style.setProperty("--glare-opacity", "1");
-    // Enquanto o ponteiro esta em cima, a transicao e curta o suficiente
-    // para suavizar sem dar sensacao de atraso.
-    card.style.setProperty("--tilt-ease", "90ms");
-  };
-
-  const handlePointerLeave = () => {
-    const card = cardRef.current;
-    if (!card) return;
-
-    // Na saida, volta devagar ao repouso.
-    card.style.setProperty("--tilt-ease", "450ms");
-    card.style.setProperty("--tilt-x", "0deg");
-    card.style.setProperty("--tilt-y", "0deg");
-    card.style.setProperty("--glare-opacity", "0");
-  };
+  const { ref, onPointerMove, onPointerLeave } = useTilt<HTMLDivElement>();
 
   return (
     <div
-      ref={cardRef}
-      className="card-3d flex min-h-[7.5rem] w-full max-w-[15rem] flex-col items-center justify-center gap-y-1 rounded-xl bg-zinc-200 px-4 shadow-[var(--card-shadow)] dark:bg-zinc-900"
-      onPointerMove={handlePointerMove}
-      onPointerLeave={handlePointerLeave}
+      ref={ref}
+      onPointerMove={onPointerMove}
+      onPointerLeave={onPointerLeave}
+      className="card-3d flex min-h-[7.5rem] w-full max-w-[15rem] flex-col items-center justify-center gap-y-1 rounded-xl bg-zinc-200 px-4 shadow-[var(--card-shadow)] md:max-w-none dark:bg-zinc-900"
       aria-live={live ? "polite" : undefined}
     >
       <label htmlFor={id} className="text-lg font-medium">

--- a/src/components/result-details.tsx
+++ b/src/components/result-details.tsx
@@ -27,7 +27,7 @@ export const ResultDetails = ({
   const unit = resultIsBinary ? "bits" : "dígitos";
 
   return (
-    <section className="w-full max-w-[585px]">
+    <section className="w-full max-w-[var(--content-max)]">
       <button
         type="button"
         onClick={onToggle}

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -1,3 +1,5 @@
+import { useTilt } from "../hooks/use-tilt";
+
 const CONVERSIONS = [
   { id: 1, binary: "1010", decimal: 10 },
   { id: 2, binary: "1101", decimal: 13 },
@@ -7,8 +9,20 @@ const CONVERSIONS = [
 ];
 
 export const Table = () => {
+  // Ângulo menor que o dos cards e sem elevar o conteúdo: numa grade de dados
+  // a inclinação é acento, não protagonista, e o filho aqui é o container de
+  // rolagem, que não convém transformar.
+  const { ref, onPointerMove, onPointerLeave } = useTilt<HTMLDivElement>({
+    maxDeg: 3,
+  });
+
   return (
-    <div className="w-full max-w-[585px] overflow-hidden rounded-xl shadow-[var(--card-shadow)] transition-shadow duration-300">
+    <div
+      ref={ref}
+      onPointerMove={onPointerMove}
+      onPointerLeave={onPointerLeave}
+      className="card-3d w-full max-w-[var(--content-max)] overflow-hidden rounded-xl shadow-[var(--card-shadow)] [--card-lift:0px]"
+    >
       <div className="overflow-x-auto">
         <table className="min-w-full text-left text-sm font-light text-zinc-800 transition-colors duration-300 dark:text-zinc-200">
           <caption className="sr-only">

--- a/src/hooks/use-tilt.ts
+++ b/src/hooks/use-tilt.ts
@@ -1,0 +1,46 @@
+import { useRef, type PointerEvent } from "react";
+
+interface TiltOptions {
+  /** Ângulo máximo de inclinação, nas duas direções. */
+  maxDeg?: number;
+}
+
+/**
+ * Inclinação seguindo o ponteiro, escrita direto no style do elemento em vez
+ * de estado: a 60fps um render do React por movimento seria descartado no
+ * frame seguinte. O CSS de .card-3d consome as variáveis daqui.
+ */
+export function useTilt<T extends HTMLElement>({ maxDeg = 7 }: TiltOptions = {}) {
+  const ref = useRef<T>(null);
+
+  const onPointerMove = (event: PointerEvent<T>) => {
+    const element = ref.current;
+    // Em toque não há ponteiro para acompanhar, e o CSS já desliga o tilt.
+    if (!element || event.pointerType !== "mouse") return;
+
+    const rect = element.getBoundingClientRect();
+    const x = (event.clientX - rect.left) / rect.width;
+    const y = (event.clientY - rect.top) / rect.height;
+
+    element.style.setProperty("--tilt-x", `${(0.5 - y) * 2 * maxDeg}deg`);
+    element.style.setProperty("--tilt-y", `${(x - 0.5) * 2 * maxDeg}deg`);
+    element.style.setProperty("--glare-x", `${x * 100}%`);
+    element.style.setProperty("--glare-y", `${y * 100}%`);
+    element.style.setProperty("--glare-opacity", "1");
+    // Sob o ponteiro a transição é curta o suficiente para suavizar sem dar
+    // sensação de atraso; na saída, longa, para o retorno ser calmo.
+    element.style.setProperty("--tilt-ease", "90ms");
+  };
+
+  const onPointerLeave = () => {
+    const element = ref.current;
+    if (!element) return;
+
+    element.style.setProperty("--tilt-ease", "450ms");
+    element.style.setProperty("--tilt-x", "0deg");
+    element.style.setProperty("--tilt-y", "0deg");
+    element.style.setProperty("--glare-opacity", "0");
+  };
+
+  return { ref, onPointerMove, onPointerLeave };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -22,19 +22,27 @@
 :root {
   color-scheme: light;
 
+  /* Largura de conteúdo compartilhada. A linha de campos e a tabela usavam
+     números independentes, e a linha acabava 30px mais larga porque sua
+     largura vinha da soma dos filhos. Com a mesma variável nos dois, as
+     bordas não podem mais divergir. */
+  --content-max: 620px;
+
   /* No claro o relevo dependia de #ffffff sobre um fundo #e4e4e7, diferença
      de luminância pequena demais para desenhar uma aresta. O que resolve não
      é escurecer a sombra difusa, é dar contorno: --card-ring traça uma
      hairline e --card-contact uma sombra curta logo abaixo da borda. No
      escuro o mesmo par existe com sinal invertido. */
-  --neu-dark: rgba(113, 113, 122, 0.5);
+  --neu-dark: rgba(82, 82, 91, 0.45);
   --neu-light: #ffffff;
-  --card-ring: rgba(24, 24, 27, 0.12);
-  --card-edge-top: rgba(255, 255, 255, 0.9);
-  --card-edge-bottom: rgba(24, 24, 27, 0.07);
-  --card-contact: rgba(24, 24, 27, 0.16);
+  --card-ring: rgba(24, 24, 27, 0.18);
+  --card-edge-top: rgba(255, 255, 255, 0.95);
+  --card-edge-bottom: rgba(24, 24, 27, 0.1);
+  --card-contact: rgba(24, 24, 27, 0.22);
   --card-glare: rgba(255, 255, 255, 0.55);
 
+  /* A geometria é comum aos dois temas; só as cores mudam. Assim reforçar o
+     claro não mexe no escuro, que já estava bom. */
   --card-shadow:
     inset 0 0 0 1px var(--card-ring),
     inset 0 1px 0 var(--card-edge-top),
@@ -70,6 +78,7 @@
     --glare-x: 50%;
     --glare-y: 50%;
     --glare-opacity: 0;
+    --card-lift: 0.75rem;
 
     transform: perspective(900px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y));
     transform-style: preserve-3d;
@@ -96,9 +105,11 @@
 
   /* O conteudo flutua sobre a face do card. O deslocamento e pequeno de
      proposito: com perspective de 900px, 12px ja da o paralaxe sem
-     ampliar o texto o suficiente para borrar. */
+     ampliar o texto o suficiente para borrar. Fica em variavel porque a
+     tabela zera o valor: o filho dela e um container de rolagem, e nao
+     convem transformar nem ampliar o texto de uma grade de dados. */
   .card-3d > * {
-    transform: translateZ(0.75rem);
+    transform: translateZ(var(--card-lift));
   }
 
   /* Em toque nao existe ponteiro para acompanhar; fica so o volume fixo. */


### PR DESCRIPTION
**Relevo no tema claro.** O anel e a sombra ainda liam fraco. Reforçados **apenas os valores do tema claro**, mantendo a geometria comum aos dois, de modo que o escuro — que já estava bom — não muda:

| variável | antes | agora |
|---|---|---|
| `--card-ring` | 0,12 | **0,18** (contraste 1,26:1 → **1,45:1**) |
| `--card-contact` | 0,16 | **0,22** |
| `--neu-dark` | zinc-500 @ 50% | **zinc-600 @ 45%** (base mais escura) |
| `--card-edge-bottom` | 0,07 | **0,10** |

**Larguras.** A linha de campos ficava 30px mais larga que a tabela porque sua largura era *resultado da soma dos filhos*: 240 + 20 + botão 95 + 20 + 240 = 615, contra os 585 fixos da tabela.

Agora existe `--content-max`, uma só variável usada pela linha, pela tabela e pelo painel de cálculo, e a linha virou grade de três colunas (`1fr auto 1fr`): as duas colunas dividem o que sobra depois do botão, então ela ocupa exatamente a largura definida em vez de deduzi-la dos filhos. Medido: os dois blocos em 620px, ambos de 330 a 950, **diferença zero**, com os cards iguais entre si.

**Tabela com 3D.** Ganhou a mesma classe dos cards, com duas diferenças deliberadas: o ângulo máximo cai de 7° para **3°**, porque numa grade de dados a inclinação é acento e não protagonista, e o deslocamento em Z do conteúdo é **zerado**, já que o filho direto é o container de rolagem — transformá-lo ampliaria o texto e criaria containing block à toa. Para isso o deslocamento virou a variável `--card-lift`, que a tabela sobrescreve.

Os handlers de inclinação estavam dentro do `ConverterCard` e agora vivem no hook `use-tilt`, parametrizado por ângulo, usado pelos dois. As props são desestruturadas no ponto de chamada porque a regra `react-hooks/refs` trata o acesso a `.ref` por propriedade de objeto como leitura de ref no render.

**Verificado:** tabela inclina a 3° e os cards a 7°, ambos voltando a zero na saída do ponteiro; o container de rolagem segue com `transform` identidade e, a 320px, ainda rola internamente com a página sem rolagem horizontal.