### PR TITLE
fix: eleva a superfície no claro e aposenta o brilho branco

### DIFF
--- a/src/components/converter-card.tsx
+++ b/src/components/converter-card.tsx
@@ -30,7 +30,7 @@ export const ConverterCard = ({
       ref={ref}
       onPointerMove={onPointerMove}
       onPointerLeave={onPointerLeave}
-      className="card-3d flex min-h-[7.5rem] w-full max-w-[15rem] flex-col items-center justify-center gap-y-1 rounded-xl bg-zinc-200 px-4 shadow-[var(--card-shadow)] md:max-w-none dark:bg-zinc-900"
+      className="card-3d flex min-h-[7.5rem] w-full max-w-[15rem] flex-col items-center justify-center gap-y-1 rounded-xl bg-[var(--card-surface)] px-4 shadow-[var(--card-shadow)] md:max-w-none"
       aria-live={live ? "polite" : undefined}
     >
       <label htmlFor={id} className="text-lg font-medium">

--- a/src/components/notification.tsx
+++ b/src/components/notification.tsx
@@ -8,8 +8,10 @@ export const Notification = ({ text, active }: NotificationProps) => {
 
   return (
     <div className="pointer-events-none fixed inset-0 z-50">
+      {/* Sobrepõe o conteúdo, então no escuro precisa de um tom acima da
+          superfície comum, que ali é igual ao fundo da página. */}
       <div
-        className="absolute top-5 right-4 left-4 ml-auto flex max-w-xs items-center rounded-lg bg-zinc-200 p-4 text-zinc-600 shadow transition-colors duration-300 dark:bg-zinc-800 dark:text-zinc-300"
+        className="absolute top-5 right-4 left-4 ml-auto flex max-w-xs items-center rounded-lg bg-[var(--card-surface)] p-4 text-zinc-600 shadow-[var(--card-shadow)] transition-colors duration-300 dark:bg-zinc-800 dark:text-zinc-300"
         role="alert"
       >
         <div className="inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-500 transition-colors duration-300 dark:bg-orange-500/20 dark:text-orange-300">

--- a/src/components/result-details.tsx
+++ b/src/components/result-details.tsx
@@ -49,7 +49,7 @@ export const ResultDetails = ({
         className="grid grid-rows-[0fr] transition-[grid-template-rows] duration-300 ease-out data-[open=true]:grid-rows-[1fr]"
       >
         <div className="overflow-hidden">
-          <div className="mt-3 flex flex-col gap-y-4 rounded-xl bg-zinc-200 p-4 text-sm shadow-[var(--card-shadow)] transition-[background-color,box-shadow] duration-300 dark:bg-zinc-900">
+          <div className="mt-3 flex flex-col gap-y-4 rounded-xl bg-[var(--card-surface)] p-4 text-sm shadow-[var(--card-shadow)] transition-[background-color,box-shadow] duration-300">
             <div>
               <h2 className="font-medium">
                 {label} completo · {result.length} {unit}

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -21,7 +21,7 @@ export const Table = () => {
       ref={ref}
       onPointerMove={onPointerMove}
       onPointerLeave={onPointerLeave}
-      className="card-3d w-full max-w-[var(--content-max)] overflow-hidden rounded-xl shadow-[var(--card-shadow)] [--card-lift:0px]"
+      className="card-3d w-full max-w-[var(--content-max)] overflow-hidden rounded-xl bg-[var(--card-surface)] shadow-[var(--card-shadow)] [--card-lift:0px]"
     >
       <div className="overflow-x-auto">
         <table className="min-w-full text-left text-sm font-light text-zinc-800 transition-colors duration-300 dark:text-zinc-200">

--- a/src/index.css
+++ b/src/index.css
@@ -33,12 +33,18 @@
      é escurecer a sombra difusa, é dar contorno: --card-ring traça uma
      hairline e --card-contact uma sombra curta logo abaixo da borda. No
      escuro o mesmo par existe com sinal invertido. */
+  /* A superfície elevada era a mesma cor da página, e um brilho branco por
+     cima disso não tinha para onde clarear: por isso não aparecia. Agora o
+     card é mais claro que a tela de fundo, que é o que separa os dois, e o
+     brilho branco sai de cena no claro. No escuro ele continua fazendo
+     efeito, porque lá há espaço de luminância acima do fundo. */
+  --card-surface: #fafafa;
   --neu-dark: rgba(82, 82, 91, 0.45);
-  --neu-light: #ffffff;
-  --card-ring: rgba(24, 24, 27, 0.18);
+  --neu-light: transparent;
+  --card-ring: rgba(24, 24, 27, 0.24);
   --card-edge-top: rgba(255, 255, 255, 0.95);
   --card-edge-bottom: rgba(24, 24, 27, 0.1);
-  --card-contact: rgba(24, 24, 27, 0.22);
+  --card-contact: rgba(24, 24, 27, 0.28);
   --card-glare: rgba(255, 255, 255, 0.55);
 
   /* A geometria é comum aos dois temas; só as cores mudam. Assim reforçar o
@@ -56,6 +62,7 @@
 .dark {
   color-scheme: dark;
 
+  --card-surface: #18181b;
   --neu-dark: #09090b;
   --neu-light: #303038;
   --card-ring: rgba(255, 255, 255, 0.07);


### PR DESCRIPTION
O brilho branco não aparecia por um motivo **estrutural**: a superfície do card tinha exatamente a mesma cor do fundo da página (`zinc-200`), e um brilho branco sobre isso não tinha para onde clarear. Tirar só a sombra deixaria o card sem separação nenhuma — então foram as duas coisas que você sugeriu.

| mudança | claro | escuro |
|---|---|---|
| `--card-surface` (nova) | `zinc-50` | `zinc-900` (igual ao que já era) |
| superfície vs. fundo da página | **1,22:1** | — |
| `--neu-light` | **`transparent`** | `#303038` (inalterado) |
| `--card-ring` | 0,18 → **0,24** (1,67:1) | 0,07 (inalterado) |
| `--card-contact` | 0,22 → **0,28** | 0,65 (inalterado) |
| camadas que pintam | **6** | **7** |

A superfície elevada virou variável e é usada pelo card, pela tabela, pelo painel de cálculo e pelo aviso. A página, a navbar e o rodapé seguem em `zinc-200`: são tela de fundo, não superfície.

A camada do brilho continua **declarada** para o `box-shadow` ter a mesma contagem nos dois temas — requisito para a transição interpolar — mas com `transparent` ela não pinta. Verificado: seis camadas pintando no claro contra sete no escuro, onde o brilho ainda faz efeito porque há espaço de luminância acima do fundo.

A tabela ganhou fundo próprio, que antes não tinha: era transparente e mostrava a página, o que no claro a deixava sem corpo. O aviso mantém override no escuro, porque sobrepõe o conteúdo e a superfície comum ali é igual ao fundo.

**Nenhum valor do tema escuro foi alterado.**