### PR TITLE
fix: cursor nos botões e botão Trocar integrado à superfície

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,10 +99,13 @@ function App() {
             placeholder={mode === "binary" ? "Ex.: 1010" : "Ex.: 10"}
           />
 
+          {/* Mesma superfície e mesma borda dos campos: o botão integra ao
+              conjunto em vez de inverter as cores, e o acento fica na borda de
+              tinta cheia, que é o que ainda o lê como ação. */}
           <button
             type="button"
             onClick={toggleMode}
-            className="flex items-center gap-x-1.5 rounded-xl border-2 border-zinc-200 bg-zinc-900 px-2.5 py-1.5 text-zinc-200 transition-colors duration-300 hover:bg-zinc-800 active:bg-zinc-700 dark:border-zinc-900 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300 dark:active:bg-zinc-400"
+            className="flex items-center gap-x-1.5 rounded-xl border border-zinc-900 bg-[var(--card-surface)] px-3 py-2 font-bold shadow-[var(--control-shadow)] transition-colors duration-300 hover:bg-zinc-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-900 active:bg-zinc-300 dark:border-zinc-100 dark:hover:bg-zinc-800 dark:focus-visible:outline-zinc-100 dark:active:bg-zinc-700"
           >
             {/* Em coluna os cards ficam um sobre o outro, então a seta aponta
                 na direção que a troca realmente acontece. */}

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,17 @@
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
+@layer base {
+  /* O preflight do Tailwind 4 deixou de trazer cursor: pointer em button, que
+     a v3 trazia, então todo botão do app estava com a seta padrão. Corrigido
+     na base, e não com uma classe por botão, para o próximo botão já nascer
+     certo. Desabilitados ficam de fora de propósito. */
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}
+
 /* O relevo dos cards e um box-shadow de valor arbitrario, que nenhuma
    variante dark: alcancaria de forma legivel. Mantendo as cores em
    variaveis, a troca de tema atinge tambem o relevo.
@@ -46,6 +57,12 @@
   --card-edge-bottom: rgba(24, 24, 27, 0.1);
   --card-contact: rgba(24, 24, 27, 0.28);
   --card-glare: rgba(255, 255, 255, 0.55);
+
+  /* Mesmo material dos cards em escala de controle: num botão de ~100px as
+     sombras difusas de 24px do card ficariam desproporcionais. */
+  --control-shadow:
+    inset 0 0 0 1px var(--card-ring),
+    0 1px 2px var(--card-contact);
 
   /* A geometria é comum aos dois temas; só as cores mudam. Assim reforçar o
      claro não mexe no escuro, que já estava bom. */


### PR DESCRIPTION
**Cursor.** O preflight do Tailwind 4 deixou de trazer `cursor: pointer` em `button`, que a v3 trazia — os três botões do app estavam com a seta padrão. Corrigido em `@layer base`, e não com uma classe por botão, para o próximo botão já nascer certo; desabilitados ficam de fora de propósito.

Verificado no CSS gerado (`button:not(:disabled),[role=button]:not(:disabled){cursor:pointer}`) e nos três botões em tela.

**Botão Trocar.** Era o único elemento que invertia as cores — branco no escuro, preto no claro — saltando da paleta. Passa a usar a mesma superfície dos cards (`--card-surface`) com a **borda de tinta cheia igual à dos campos**: integra ao conjunto e ainda lê como ação, que era o objetivo. Ganhou também estado de foco visível, que não tinha.

| | antes | agora |
|---|---|---|
| fundo (claro) | `zinc-900` | `zinc-50`, igual aos cards |
| fundo (escuro) | `zinc-100` | `zinc-900`, igual aos cards |
| borda | `zinc-200` / `zinc-900` | tinta cheia, igual à dos campos |
| peso do rótulo | 500 | **700** |
| foco visível | não tinha | `focus-visible` |

Para o relevo foi criada `--control-shadow`, com o anel e o contato de `--card-shadow` mas **sem as sombras difusas de 24px**: num botão de ~100px elas ficariam desproporcionais. Mesmo material, escala de controle.

O peso 700 já estava entre os carregados da Space Grotesk, então não há requisição de fonte adicional.