### PR TITLE
docs: reescreve o README em português e inglês

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Joseph Kawe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,161 @@
+<div align="center">
+
+<img src="./public/favicon.svg" width="76" height="76" alt="" />
+
+# Bin2Dec
+
+**Binary ↔ decimal converter with no precision limit.**
+
+[![React](https://img.shields.io/badge/React-19-087EA4?style=flat-square&logo=react&logoColor=white)](https://react.dev/)
+[![React Compiler](https://img.shields.io/badge/React_Compiler-1.0-087EA4?style=flat-square)](https://react.dev/learn/react-compiler)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.7-3178C6?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Vite](https://img.shields.io/badge/Vite-6.4-646CFF?style=flat-square&logo=vite&logoColor=white)](https://vite.dev/)
+[![Tailwind](https://img.shields.io/badge/Tailwind-4.3-06B6D4?style=flat-square&logo=tailwindcss&logoColor=white)](https://tailwindcss.com/)
+[![Vitest](https://img.shields.io/badge/Vitest-4.1-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev/)
+
+[**Live demo**](https://bin-two-dec.vercel.app/) · [Português](README.md)
+
+</div>
+
+---
+
+## What it is
+
+Converts numbers between base 2 and base 10 in both directions, with
+mode-aware input validation and arbitrary precision:
+`1111111111111111111111111111111111111111111111111111111111111111` returns
+`18446744073709551615`, exactly, not a rounded value.
+
+When the result outgrows the field, a panel shows the whole number grouped for
+reading plus the sum of powers of two that produces it.
+
+## Interface
+
+Light and dark themes, choice persisted and applied before first paint. Cards
+with layered depth and pointer-tracking tilt, disabled on touch and under
+`prefers-reduced-motion`.
+
+<!-- To show the screenshots, drop both files in public/ and replace this
+     comment with the block below:
+
+| Light | Dark |
+|:-----:|:----:|
+| <img src="./public/screenshot-light.png" alt="Light theme" /> | <img src="./public/screenshot-dark.png" alt="Dark theme" /> |
+-->
+
+## Design decisions
+
+What sets this apart from a converter written in a hurry.
+
+**`BigInt` instead of `parseInt`.** `parseInt(v, 2)` stops at the first digit
+outside the alphabet and returns what it read so far: `"19"` became `1`, a
+wrong answer with no warning. Past `Number.MAX_SAFE_INTEGER` the conversion
+lost precision, and long inputs became the string `"Infinity"`, because
+`isNaN(Infinity)` is `false`. All four cases are pinned by tests.
+
+**Derived result, not state.** The converted value is computed during render
+from the input and the mode. There is no `useState` or `useEffect` for it,
+which structurally removes both the effect that ignored mode changes and the
+one-frame stale result. React Compiler memoizes the derivation.
+
+**Depth in CSS variables.** The shadows are arbitrary values with hardcoded
+colors, which no `dark:` variant could reach legibly. Keeping the colors in
+variables redefined under `.dark` means switching themes also switches the
+depth, not just background and text.
+
+**Shared content width.** `--content-max` is used by the field row, the table
+and the panel. The row is a `1fr auto 1fr` grid, so it occupies the defined
+width instead of deriving it from the sum of its children — which is how the
+two blocks had drifted 30px apart.
+
+**Icons from two sources.** [Lucide](https://lucide.dev/) for UI and
+[Simple Icons](https://simpleicons.org/) for brands, because Lucide 1.x
+dropped every brand icon. LinkedIn is hand-drawn: Simple Icons removed it at
+the trademark holder's request.
+
+## Stack
+
+| | | |
+|---|---|---|
+| [React](https://react.dev/) | 19 | UI |
+| [React Compiler](https://react.dev/learn/react-compiler) | 1.0 | Automatic memoization |
+| [TypeScript](https://www.typescriptlang.org/) | 5.7 | Types, strict mode |
+| [Vite](https://vite.dev/) | 6.4 | Build and dev server |
+| [Tailwind CSS](https://tailwindcss.com/) | 4.3 | Styling, configured in CSS |
+| [Vitest](https://vitest.dev/) | 4.1 | Tests |
+| [Bun](https://bun.sh/) | 1.2 | Package manager |
+
+## Running
+
+```bash
+git clone https://github.com/dev-kohako/BinTwoDec.git
+cd BinTwoDec
+bun install
+bun dev
+```
+
+Served at `http://localhost:5173`. Works the same with `npm`, but the
+committed lockfile is Bun's.
+
+## Scripts
+
+| | |
+|---|---|
+| `bun dev` | Dev server with HMR |
+| `bun run build` | Type check and production build into `dist/` |
+| `bun run preview` | Serve the production build locally |
+| `bun run lint` | ESLint, including the React Compiler rules |
+| `bun test` | Test suite |
+| `bun run test:watch` | Tests in watch mode |
+
+## Tests
+
+The conversion logic lives isolated in `src/lib/conversion.ts`, free of React,
+and that is where the tests focus. They run in a node environment, no DOM.
+
+```bash
+bun test
+```
+
+There is a regression block covering the four defects the conversion once
+had. The suite was checked against the old `parseInt` implementation: the
+tests meant to catch each case do fail, which proves they are not vacuous.
+The round-trip uses a fixed-seed generator rather than `Math.random`, so a
+failure stays reproducible.
+
+## Structure
+
+```
+src/
+├── components/     UI, one file per component
+├── hooks/          use-theme (theme) and use-tilt (3D tilt)
+├── lib/            conversion.ts and conversion.test.ts
+├── types/          shared types
+├── App.tsx
+├── main.tsx
+└── index.css       theme, depth variables and the .card-3d class
+```
+
+Tailwind 4 needs no `tailwind.config`: theme and variants live in
+`src/index.css`, through `@theme` and `@custom-variant`.
+
+## Deploy
+
+Published on [Vercel](https://bin-two-dec.vercel.app/), rebuilt automatically
+on every push to `main`.
+
+| | |
+|---|---|
+| Framework | Vite |
+| Build | `bun run build` |
+| Output | `dist` |
+
+## License
+
+[MIT](LICENSE).
+
+## Author
+
+**Joseph Kawe** — [GitHub](https://github.com/dev-kohako) ·
+[LinkedIn](https://www.linkedin.com/in/josephkawe/) ·
+[Bento](https://bento.me/kohako)

--- a/README.md
+++ b/README.md
@@ -1,163 +1,160 @@
-# Bin2Dec 🔢
-
-A sleek and modern web application that converts binary numbers (base 2) to decimal numbers (base 10). Built with React, TypeScript, TailwindCSS, and Vite, this project showcases a clean, minimalist, and highly functional frontend implementation.
-
 <div align="center">
-  <img src="./public/screenshot.png" alt="Bin2Dec Application Preview" width="600" />
+
+<img src="./public/favicon.svg" width="76" height="76" alt="" />
+
+# Bin2Dec
+
+**Conversor binário ↔ decimal sem limite de precisão.**
+
+[![React](https://img.shields.io/badge/React-19-087EA4?style=flat-square&logo=react&logoColor=white)](https://react.dev/)
+[![React Compiler](https://img.shields.io/badge/React_Compiler-1.0-087EA4?style=flat-square)](https://react.dev/learn/react-compiler)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.7-3178C6?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Vite](https://img.shields.io/badge/Vite-6.4-646CFF?style=flat-square&logo=vite&logoColor=white)](https://vite.dev/)
+[![Tailwind](https://img.shields.io/badge/Tailwind-4.3-06B6D4?style=flat-square&logo=tailwindcss&logoColor=white)](https://tailwindcss.com/)
+[![Vitest](https://img.shields.io/badge/Vitest-4.1-6E9F18?style=flat-square&logo=vitest&logoColor=white)](https://vitest.dev/)
+
+[**Ver funcionando**](https://bin-two-dec.vercel.app/) · [English](README.en.md)
+
 </div>
 
 ---
 
-## 🚀 Live Demo
+## O que é
 
-Experience the app in action: **[https://bin-two-dec.vercel.app/](https://bin-two-dec.vercel.app/)**
+Converte números entre base 2 e base 10 nos dois sentidos, com validação de
+entrada dependente do modo e precisão arbitrária: `1111111111111111111111111111111111111111111111111111111111111111`
+devolve `18446744073709551615`, exato, e não um arredondamento.
 
----
+Quando o resultado não cabe no campo, um painel mostra o número inteiro
+agrupado e a expansão em potências de 2 que chega até ele.
 
-## ✨ Features
+## Interface
 
-- 🔄 **Instant Conversion**: Real-time binary to decimal conversion
-- 🛡️ **Input Validation**: Accepts only valid binary digits (0 and 1)
-- 📱 **Responsive Design**: Fully responsive interface built with TailwindCSS
-- ⚡ **Lightning Fast**: Optimized build process with Vite
-- 🔧 **Type Safety**: Written entirely in TypeScript
-- 🎨 **Modern UI**: Clean and intuitive user interface
+Tema claro e escuro, escolha persistida e aplicada antes do primeiro paint.
+Cards com relevo e inclinação seguindo o cursor, desligada em toque e sob
+`prefers-reduced-motion`.
 
----
+<!-- Para exibir as capturas, coloque os dois arquivos em public/ e troque
+     este comentário pelo bloco abaixo:
 
-## 🛠️ Tech Stack
+| Claro | Escuro |
+|:-----:|:------:|
+| <img src="./public/screenshot-light.png" alt="Tema claro" /> | <img src="./public/screenshot-dark.png" alt="Tema escuro" /> |
+-->
 
-| Technology | Version | Purpose |
-|------------|---------|---------|
-| [React](https://react.dev/) | 19 | Frontend Framework |
-| [TypeScript](https://www.typescriptlang.org/) | Latest | Type Safety |
-| [Vite](https://vitejs.dev/) | 6 | Build Tool & Dev Server |
-| [TailwindCSS](https://tailwindcss.com/) | 4 | Styling Framework |
-| [ESLint](https://eslint.org/) | Latest | Code Linting |
+## Decisões de projeto
 
----
+O que faria diferente de um conversor escrito às pressas.
 
-## 🚀 Quick Start
+**`BigInt` em vez de `parseInt`.** `parseInt(v, 2)` para no primeiro dígito
+fora do alfabeto e devolve o que leu até ali: `"19"` virava `1`, resultado
+errado sem aviso nenhum. Acima de `Number.MAX_SAFE_INTEGER` a conversão
+perdia precisão, e entradas longas viravam a string `"Infinity"`, porque
+`isNaN(Infinity)` é `false`. Os quatro casos estão fixados em teste.
 
-### Prerequisites
-- Node.js (v18 or higher)
-- npm or yarn package manager
+**Resultado derivado, não estado.** O valor convertido é calculado no render
+a partir da entrada e do modo. Não há `useState` nem `useEffect` para ele, o
+que remove por construção o efeito que não reagia à troca de modo e o
+resultado defasado em um frame. O React Compiler memoiza a derivação.
 
-### Installation
+**Relevo em variáveis CSS.** As sombras são valores arbitrários com cor fixa,
+que nenhuma variante `dark:` alcançaria de forma legível. Mantendo as cores
+em variáveis redefinidas em `.dark`, a troca de tema atinge também o relevo,
+e não só fundo e texto.
+
+**Largura de conteúdo compartilhada.** `--content-max` é usada pela linha de
+campos, pela tabela e pelo painel. A linha é uma grade `1fr auto 1fr`, então
+ocupa a largura definida em vez de deduzi-la da soma dos filhos, que é como
+os dois blocos tinham divergido em 30px.
+
+**Ícones de duas fontes.** [Lucide](https://lucide.dev/) para interface e
+[Simple Icons](https://simpleicons.org/) para as marcas, porque o Lucide 1.x
+removeu todos os ícones de marca. A LinkedIn é desenhada à mão: o Simple
+Icons a removeu por pedido de titular.
+
+## Stack
+
+| | | |
+|---|---|---|
+| [React](https://react.dev/) | 19 | Interface |
+| [React Compiler](https://react.dev/learn/react-compiler) | 1.0 | Memoização automática |
+| [TypeScript](https://www.typescriptlang.org/) | 5.7 | Tipagem, modo estrito |
+| [Vite](https://vite.dev/) | 6.4 | Build e dev server |
+| [Tailwind CSS](https://tailwindcss.com/) | 4.3 | Estilo, configurado em CSS |
+| [Vitest](https://vitest.dev/) | 4.1 | Testes |
+| [Bun](https://bun.sh/) | 1.2 | Gerenciador de pacotes |
+
+## Rodando
 
 ```bash
-# Clone the repository
-git clone https://github.com/your-username/bin2dec.git
-cd bin2dec
-
-# Install dependencies
-npm install
-
-# Start development server
-npm run dev
+git clone https://github.com/dev-kohako/BinTwoDec.git
+cd BinTwoDec
+bun install
+bun dev
 ```
 
-The application will be available at `http://localhost:5173`
+Disponível em `http://localhost:5173`. Funciona igual com `npm`, mas o
+lockfile versionado é o do Bun.
 
----
+## Scripts
 
-## 📜 Available Scripts
+| | |
+|---|---|
+| `bun dev` | Dev server com HMR |
+| `bun run build` | Type check e build de produção em `dist/` |
+| `bun run preview` | Serve o build localmente |
+| `bun run lint` | ESLint, incluindo as regras do React Compiler |
+| `bun test` | Suíte de testes |
+| `bun run test:watch` | Testes em modo watch |
 
-| Command | Description |
-|---------|-------------|
-| `npm run dev` | Starts the development server with hot reload |
-| `npm run build` | Creates optimized production build in `dist/` |
-| `npm run preview` | Serves the production build locally |
-| `npm run lint` | Runs ESLint to check for code issues |
-| `npm run lint:fix` | Automatically fixes linting issues |
+## Testes
 
----
+A lógica de conversão vive isolada em `src/lib/conversion.ts`, sem React, e é
+onde os testes se concentram. Rodam em ambiente node, sem DOM.
 
-## 📁 Project Structure
-
-```
-bin2dec/
-├── public/
-│   ├── KWK.png
-│   └── screenshot.png
-├── src/
-│   ├── components/
-│   │   └── [Component files]
-│   ├── types/
-│   │   └── [Type definitions]
-│   ├── utils/
-│   │   └── [Utility functions]
-│   ├── App.tsx
-│   ├── main.tsx
-│   ├── index.css
-│   └── vite-env.d.ts
-├── index.html
-├── vite.config.ts
-├── tailwind.config.ts
-├── tsconfig.json
-├── package.json
-├── eslint.config.js
-└── README.md
-```
-
----
-
-## 🌐 Deployment
-
-This project is configured for seamless deployment on **Vercel**:
-
-### Automatic Deployment
-- Connected to GitHub for continuous deployment
-- Automatically builds and deploys on every push to main branch
-- Build output directory: `dist/`
-
-### Manual Deployment
 ```bash
-# Build for production
-npm run build
-
-# Deploy to Vercel (requires Vercel CLI)
-vercel --prod
+bun test
 ```
 
-### Environment Configuration
-- **Framework Preset**: Vite
-- **Build Command**: `npm run build`
-- **Output Directory**: `dist`
-- **Install Command**: `npm install`
+Há um bloco de regressão com os quatro defeitos que a conversão já teve. A
+suíte foi conferida contra a implementação antiga com `parseInt`: os testes
+que deveriam pegar cada caso falham, o que mostra que não são testes vazios.
+O round-trip usa gerador com semente fixa, não `Math.random`, para uma falha
+continuar reproduzível.
 
----
+## Estrutura
 
-## 🤝 Contributing
+```
+src/
+├── components/     interface, um arquivo por componente
+├── hooks/          use-theme (tema) e use-tilt (inclinação 3D)
+├── lib/            conversion.ts e conversion.test.ts
+├── types/          tipos compartilhados
+├── App.tsx
+├── main.tsx
+└── index.css       tema, variáveis de relevo e a classe .card-3d
+```
 
-Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
+O Tailwind 4 dispensa `tailwind.config`: tema e variantes ficam em
+`src/index.css`, via `@theme` e `@custom-variant`.
 
-### Development Guidelines
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/AmazingFeature`)
-3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
-4. Push to the branch (`git push origin feature/AmazingFeature`)
-5. Open a Pull Request
+## Deploy
 
----
+Publicado na [Vercel](https://bin-two-dec.vercel.app/), com build automático
+a cada push na `main`.
 
-## 📄 License
+| | |
+|---|---|
+| Framework | Vite |
+| Build | `bun run build` |
+| Saída | `dist` |
 
-This project is open source and available under the [MIT License](LICENSE).
+## Licença
 
----
+[MIT](LICENSE).
 
-## 👨‍💻 Author
+## Autor
 
-**Joseph Kawe**
-
-- GitHub: [https://github.com/dev-kohako](https://github.com/dev-kohako)
-- LinkedIn: [https://www.linkedin.com/in/josephkawe/](https://www.linkedin.com/in/josephkawe/)
-- Email: josephkawe000@gmail.com
-
----
-
-<div align="center">
-  <p>Made with ❤️ by Joseph Kawe</p>
-  <p>⭐ Star this repository if you found it helpful!</p>
-</div>
+**Joseph Kawe** — [GitHub](https://github.com/dev-kohako) ·
+[LinkedIn](https://www.linkedin.com/in/josephkawe/) ·
+[Bento](https://bento.me/kohako)


### PR DESCRIPTION
O README anterior era um template genérico e, pior, **apontava para várias coisas que não existem no repositório**:

| o que dizia | realidade |
|---|---|
| `public/screenshot.png` no topo | arquivo não existe → **imagem quebrada** |
| link de licença para `LICENSE` | arquivo não existia → **link quebrado** |
| estrutura com `src/utils` e `tailwind.config.ts` | nenhum dos dois existe; faltavam `src/hooks` e `src/lib` |
| script `npm run lint:fix` | nunca existiu |
| `git clone .../your-username/bin2dec.git` | placeholder |
| "converts binary to decimal" | converte nos **dois** sentidos |
| stack sem React Compiler, Lucide, Simple Icons, Vitest | e indicava `npm` com lockfile do Bun versionado |

Agora são dois arquivos, **português como principal** e `README.en.md` ao lado, com link entre eles. Todo caminho, script e diretório citado foi conferido contra o repositório — inclusive verifiquei que as duas capturas ficam **dentro de um bloco comentado**, com o markdown pronto para quando os arquivos entrarem, sem link quebrado no meio tempo.

## O que faz ser um padrão e não um template

A seção **Decisões de projeto** registra o *porquê*, e cada item tem um bug ou limitação concreta atrás:

- `BigInt` em vez de `parseInt` — os quatro defeitos reais que a conversão teve
- resultado derivado, não estado — remove por construção o efeito que ignorava a troca de modo
- relevo em variáveis CSS — nenhuma variante `dark:` alcança valor arbitrário de sombra
- largura de conteúdo compartilhada — foi assim que os dois blocos divergiram 30px
- ícones de duas fontes — Lucide 1.x removeu marcas; Simple Icons removeu a LinkedIn

`LICENSE` foi criado com o texto MIT, tornando verdadeira a declaração que o README já fazia. **Ajuste o ano e o titular se necessário.**

O deploy documentado é a Vercel, que é a que serve o bundle compilado.