### PR TITLE
docs: reescreve a seção de decisões afirmando o que o código faz

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -43,30 +43,26 @@ with layered depth and pointer-tracking tilt, disabled on touch and under
 | <img src="./public/screenshot-light.png" alt="Light theme" /> | <img src="./public/screenshot-dark.png" alt="Dark theme" /> |
 -->
 
-## Design decisions
+## How it is built
 
-What sets this apart from a converter written in a hurry.
-
-**`BigInt` instead of `parseInt`.** `parseInt(v, 2)` stops at the first digit
-outside the alphabet and returns what it read so far: `"19"` became `1`, a
-wrong answer with no warning. Past `Number.MAX_SAFE_INTEGER` the conversion
-lost precision, and long inputs became the string `"Infinity"`, because
-`isNaN(Infinity)` is `false`. All four cases are pinned by tests.
+**Precision through `BigInt`.** Every conversion goes through `BigInt`, so
+there is no size ceiling and no rounding: 64 set bits return
+`18446744073709551615` exactly. Input validation follows the mode, so binary
+mode accepts only `0` and `1`.
 
 **Derived result, not state.** The converted value is computed during render
-from the input and the mode. There is no `useState` or `useEffect` for it,
-which structurally removes both the effect that ignored mode changes and the
-one-frame stale result. React Compiler memoizes the derivation.
+from the input and the mode, with no `useState` or `useEffect` of its own. One
+less piece of state to keep in sync, and React Compiler memoizes the
+derivation.
 
-**Depth in CSS variables.** The shadows are arbitrary values with hardcoded
-colors, which no `dark:` variant could reach legibly. Keeping the colors in
-variables redefined under `.dark` means switching themes also switches the
-depth, not just background and text.
+**The theme reaches the depth.** Shadow colors live in CSS variables redefined
+under `.dark`, so switching themes also switches the card depth, not just
+background and text — an arbitrary `box-shadow` value is not reachable by a
+`dark:` variant.
 
-**Shared content width.** `--content-max` is used by the field row, the table
-and the panel. The row is a `1fr auto 1fr` grid, so it occupies the defined
-width instead of deriving it from the sum of its children — which is how the
-two blocks had drifted 30px apart.
+**Shared content width.** `--content-max` defines the width and is used by the
+field row, the table and the panel. The row is a `1fr auto 1fr` grid, so it
+occupies that width instead of deriving it from the sum of its children.
 
 **Icons from two sources.** [Lucide](https://lucide.dev/) for UI and
 [Simple Icons](https://simpleicons.org/) for brands, because Lucide 1.x
@@ -117,11 +113,10 @@ and that is where the tests focus. They run in a node environment, no DOM.
 bun test
 ```
 
-There is a regression block covering the four defects the conversion once
-had. The suite was checked against the old `parseInt` implementation: the
-tests meant to catch each case do fail, which proves they are not vacuous.
-The round-trip uses a fixed-seed generator rather than `Math.random`, so a
-failure stays reproducible.
+The edge cases are pinned: digits outside the alphabet in binary mode, values
+past `Number.MAX_SAFE_INTEGER`, very long inputs, empty input and leading
+zeros. The round-trip uses a fixed-seed generator rather than `Math.random`,
+so a failure stays reproducible on the next run.
 
 ## Structure
 

--- a/README.md
+++ b/README.md
@@ -42,30 +42,27 @@ Cards com relevo e inclinação seguindo o cursor, desligada em toque e sob
 | <img src="./public/screenshot-light.png" alt="Tema claro" /> | <img src="./public/screenshot-dark.png" alt="Tema escuro" /> |
 -->
 
-## Decisões de projeto
+## Como foi construído
 
-O que faria diferente de um conversor escrito às pressas.
+**Precisão com `BigInt`.** Toda conversão passa por `BigInt`, então não existe
+teto de tamanho nem arredondamento: 64 bits ligados devolvem
+`18446744073709551615` exato. A validação da entrada acompanha o modo, então
+o modo binário aceita apenas `0` e `1`.
 
-**`BigInt` em vez de `parseInt`.** `parseInt(v, 2)` para no primeiro dígito
-fora do alfabeto e devolve o que leu até ali: `"19"` virava `1`, resultado
-errado sem aviso nenhum. Acima de `Number.MAX_SAFE_INTEGER` a conversão
-perdia precisão, e entradas longas viravam a string `"Infinity"`, porque
-`isNaN(Infinity)` é `false`. Os quatro casos estão fixados em teste.
+**Resultado derivado, não estado.** O valor convertido é calculado no render a
+partir da entrada e do modo, sem `useState` nem `useEffect` próprios. Um
+estado a menos para manter em sincronia, e o React Compiler memoiza a
+derivação.
 
-**Resultado derivado, não estado.** O valor convertido é calculado no render
-a partir da entrada e do modo. Não há `useState` nem `useEffect` para ele, o
-que remove por construção o efeito que não reagia à troca de modo e o
-resultado defasado em um frame. O React Compiler memoiza a derivação.
+**O tema alcança o relevo.** As cores das sombras vivem em variáveis CSS
+redefinidas em `.dark`, então trocar de tema muda também o relevo dos cards, e
+não só fundo e texto — um `box-shadow` de valor arbitrário não é alcançável
+por variante `dark:`.
 
-**Relevo em variáveis CSS.** As sombras são valores arbitrários com cor fixa,
-que nenhuma variante `dark:` alcançaria de forma legível. Mantendo as cores
-em variáveis redefinidas em `.dark`, a troca de tema atinge também o relevo,
-e não só fundo e texto.
-
-**Largura de conteúdo compartilhada.** `--content-max` é usada pela linha de
-campos, pela tabela e pelo painel. A linha é uma grade `1fr auto 1fr`, então
-ocupa a largura definida em vez de deduzi-la da soma dos filhos, que é como
-os dois blocos tinham divergido em 30px.
+**Largura de conteúdo compartilhada.** `--content-max` define a largura e é
+usada pela linha de campos, pela tabela e pelo painel. A linha é uma grade
+`1fr auto 1fr`, então ocupa essa largura em vez de deduzi-la da soma dos
+filhos.
 
 **Ícones de duas fontes.** [Lucide](https://lucide.dev/) para interface e
 [Simple Icons](https://simpleicons.org/) para as marcas, porque o Lucide 1.x
@@ -116,11 +113,10 @@ onde os testes se concentram. Rodam em ambiente node, sem DOM.
 bun test
 ```
 
-Há um bloco de regressão com os quatro defeitos que a conversão já teve. A
-suíte foi conferida contra a implementação antiga com `parseInt`: os testes
-que deveriam pegar cada caso falham, o que mostra que não são testes vazios.
-O round-trip usa gerador com semente fixa, não `Math.random`, para uma falha
-continuar reproduzível.
+Os casos-limite estão fixados: dígito fora do alfabeto no modo binário,
+valores acima de `Number.MAX_SAFE_INTEGER`, entradas muito longas, entrada
+vazia e zeros à esquerda. O round-trip usa gerador com semente fixa, e não
+`Math.random`, para que uma falha continue reproduzível na execução seguinte.
 
 ## Estrutura
 


### PR DESCRIPTION
A seção narrava **histórico de defeitos** em vez de decisões. Num README que é vitrine do projeto, ela anunciava publicamente que "o resultado saía errado sem aviso" e que "dois blocos tinham divergido em 30px" — e abria com *"o que faria diferente de um conversor escrito às pressas"*, insinuando que o código anterior era apressado.

A substância técnica continua. O que muda é afirmar o que a implementação **faz**, sem contar o que ela já teve de errado:

| antes | agora |
|---|---|
| `parseInt` parava no primeiro dígito inválido, `"19"` virava `1`… | **Precisão com `BigInt`**: sem teto nem arredondamento, validação acompanha o modo |
| …remove o efeito que **não reagia** à troca de modo e o resultado **defasado** | **Resultado derivado**: um estado a menos para manter em sincronia |
| sombras que nenhuma variante `dark:` **alcançaria** | **O tema alcança o relevo**: as cores vivem em variáveis redefinidas em `.dark` |
| …**é como os dois blocos tinham divergido** em 30px | **Largura compartilhada**: a linha ocupa a largura definida em vez de deduzi-la |

Título passa de "Decisões de projeto" para **"Como foi construído"**, que é o que a seção de fato entrega.

A seção de testes recebeu o mesmo tratamento: em vez de citar os quatro defeitos que a conversão teve, lista os casos-limite que ficam fixados.

Aplicado nos dois idiomas. Verificado que não sobrou nenhuma narrativa de defeito em nenhum dos dois arquivos.