### PR TITLE
docs: reescreve o README em primeira pessoa

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -4,7 +4,7 @@
 
 # Bin2Dec
 
-**Binary ↔ decimal converter with no precision limit.**
+**Binary ↔ decimal. No size limit, no rounding.**
 
 [![React](https://img.shields.io/badge/React-19-087EA4?style=flat-square&logo=react&logoColor=white)](https://react.dev/)
 [![React Compiler](https://img.shields.io/badge/React_Compiler-1.0-087EA4?style=flat-square)](https://react.dev/learn/react-compiler)
@@ -19,21 +19,25 @@
 
 ---
 
-## What it is
+## The short version
 
-Converts numbers between base 2 and base 10 in both directions, with
-mode-aware input validation and arbitrary precision:
-`1111111111111111111111111111111111111111111111111111111111111111` returns
-`18446744073709551615`, exactly, not a rounded value.
+You type a number, it gives it back in the other base. Decimal → binary, binary
+→ decimal, and the field only accepts what makes sense for the mode it is in —
+no letting you type `7` in binary and pretending that worked.
 
-When the result outgrows the field, a panel shows the whole number grouped for
-reading plus the sum of powers of two that produces it.
+The part I would not give up: **there is no ceiling**. Paste a 300-digit number
+and the answer comes out exact, with no friendly rounding along the way. And if
+the result outgrows the field, a panel opens with the whole number grouped for
+reading, plus the sum of powers of two that gets you there.
 
-## Interface
+The interface is in Portuguese, on purpose.
 
-Light and dark themes, choice persisted and applied before first paint. Cards
-with layered depth and pointer-tracking tilt, disabled on touch and under
-`prefers-reduced-motion`.
+## The look
+
+Light and dark themes, your choice remembered and applied before the first
+paint — none of that white flash on load. The cards have real depth and tilt
+along with your cursor; on touch that makes no sense, so it goes away, and
+anyone who asked for `prefers-reduced-motion` sees nothing moving.
 
 <!-- To show the screenshots, drop both files in public/ and replace this
      comment with the block below:
@@ -43,33 +47,31 @@ with layered depth and pointer-tracking tilt, disabled on touch and under
 | <img src="./public/screenshot-light.png" alt="Light theme" /> | <img src="./public/screenshot-dark.png" alt="Dark theme" /> |
 -->
 
-## How it is built
+## Under the hood
 
-**Precision through `BigInt`.** Every conversion goes through `BigInt`, so
-there is no size ceiling and no rounding: 64 set bits return
-`18446744073709551615` exactly. Input validation follows the mode, so binary
-mode accepts only `0` and `1`.
+Four choices I would make again.
 
-**Derived result, not state.** The converted value is computed during render
-from the input and the mode, with no `useState` or `useEffect` of its own. One
-less piece of state to keep in sync, and React Compiler memoizes the
-derivation.
+**`BigInt` all the way through.** That is what makes 64 set bits come back as
+`18446744073709551615`, exactly. With a regular number, the last digits are
+decoration. Input validation follows the mode, so binary takes `0` and `1` and
+nothing else.
 
-**The theme reaches the depth.** Shadow colors live in CSS variables redefined
-under `.dark`, so switching themes also switches the card depth, not just
-background and text — an arbitrary `box-shadow` value is not reachable by a
-`dark:` variant.
+**The result is derived, not stored.** It comes out of a computation during
+render, from the input and the mode. No `useState`, no `useEffect`. One less
+piece of state to keep in sync is one less bug to chase later — and React
+Compiler memoizes the computation on its own.
 
-**Shared content width.** `--content-max` defines the width and is used by the
-field row, the table and the panel. The row is a `1fr auto 1fr` grid, so it
-occupies that width instead of deriving it from the sum of its children.
+**The theme reaches the depth.** Switching themes here does not just change
+background and text: the shadow colors live in CSS variables redefined under
+`.dark`, so the card depth switches along. An arbitrary `box-shadow` value is
+something no `dark:` variant can reach.
 
-**Icons from two sources.** [Lucide](https://lucide.dev/) for UI and
-[Simple Icons](https://simpleicons.org/) for brands, because Lucide 1.x
-dropped every brand icon. LinkedIn is hand-drawn: Simple Icons removed it at
-the trademark holder's request.
+**One width, three blocks.** `--content-max` drives the field row, the table
+and the panel. The row is a `1fr auto 1fr` grid, so it occupies that width
+instead of inferring it from the sum of its children — which is how two blocks
+stop lining up without anyone noticing.
 
-## Stack
+## Built with
 
 | | | |
 |---|---|---|
@@ -81,7 +83,7 @@ the trademark holder's request.
 | [Vitest](https://vitest.dev/) | 4.1 | Tests |
 | [Bun](https://bun.sh/) | 1.2 | Package manager |
 
-## Running
+## Running it locally
 
 ```bash
 git clone https://github.com/dev-kohako/BinTwoDec.git
@@ -90,8 +92,8 @@ bun install
 bun dev
 ```
 
-Served at `http://localhost:5173`. Works the same with `npm`, but the
-committed lockfile is Bun's.
+Opens at `http://localhost:5173`. Works the same with `npm` — just know the
+committed lockfile here is Bun's.
 
 ## Scripts
 
@@ -100,25 +102,27 @@ committed lockfile is Bun's.
 | `bun dev` | Dev server with HMR |
 | `bun run build` | Type check and production build into `dist/` |
 | `bun run preview` | Serve the production build locally |
-| `bun run lint` | ESLint, including the React Compiler rules |
-| `bun test` | Test suite |
+| `bun run lint` | ESLint, with the React Compiler rules |
+| `bun test` | Run the tests |
 | `bun run test:watch` | Tests in watch mode |
 
 ## Tests
 
-The conversion logic lives isolated in `src/lib/conversion.ts`, free of React,
-and that is where the tests focus. They run in a node environment, no DOM.
+The conversion math lives on its own in `src/lib/conversion.ts`, free of React,
+and that is where the tests aim. They run in node, no DOM, and finish before
+you take your hand off the keyboard.
 
 ```bash
 bun test
 ```
 
-The edge cases are pinned: digits outside the alphabet in binary mode, values
-past `Number.MAX_SAFE_INTEGER`, very long inputs, empty input and leading
-zeros. The round-trip uses a fixed-seed generator rather than `Math.random`,
-so a failure stays reproducible on the next run.
+What is pinned are the corners where this kind of code tends to slip: digits
+outside the alphabet in binary mode, values past `Number.MAX_SAFE_INTEGER`, a
+huge input, empty input and leading zeros. The round-trip uses a fixed-seed
+generator instead of `Math.random`, otherwise a failure shows up today and
+vanishes tomorrow.
 
-## Structure
+## Where things are
 
 ```
 src/
@@ -131,13 +135,17 @@ src/
 └── index.css       theme, depth variables and the .card-3d class
 ```
 
+If you came for the code and want to read just one thing, read
+[`src/lib/conversion.ts`](src/lib/conversion.ts). It is the heart of it and
+under a hundred lines.
+
 Tailwind 4 needs no `tailwind.config`: theme and variants live in
 `src/index.css`, through `@theme` and `@custom-variant`.
 
 ## Deploy
 
-Published on [Vercel](https://bin-two-dec.vercel.app/), rebuilt automatically
-on every push to `main`.
+Running on [Vercel](https://bin-two-dec.vercel.app/), rebuilt on every push to
+`main`.
 
 | | |
 |---|---|
@@ -147,10 +155,14 @@ on every push to `main`.
 
 ## License
 
-[MIT](LICENSE).
+[MIT](LICENSE) — take it, use it, change it. If it helped, tell me.
 
-## Author
+## Who made it
 
-**Joseph Kawe** — [GitHub](https://github.com/dev-kohako) ·
+**Joseph Kawe**, under the KWK name.
+
+[GitHub](https://github.com/dev-kohako) ·
 [LinkedIn](https://www.linkedin.com/in/josephkawe/) ·
+[Instagram](https://www.instagram.com/kohako.dev/) ·
+[YouTube](https://www.youtube.com/@dev_kohako) ·
 [Bento](https://bento.me/kohako)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Bin2Dec
 
-**Conversor binário ↔ decimal sem limite de precisão.**
+**Binário ↔ decimal. Sem limite de tamanho, sem arredondar.**
 
 [![React](https://img.shields.io/badge/React-19-087EA4?style=flat-square&logo=react&logoColor=white)](https://react.dev/)
 [![React Compiler](https://img.shields.io/badge/React_Compiler-1.0-087EA4?style=flat-square)](https://react.dev/learn/react-compiler)
@@ -19,20 +19,25 @@
 
 ---
 
-## O que é
+## Em resumo
 
-Converte números entre base 2 e base 10 nos dois sentidos, com validação de
-entrada dependente do modo e precisão arbitrária: `1111111111111111111111111111111111111111111111111111111111111111`
-devolve `18446744073709551615`, exato, e não um arredondamento.
+Você digita um número, ele devolve na outra base. Decimal → binário, binário →
+decimal, e o campo só aceita o que faz sentido no modo em que está — nada de
+deixar você digitar `7` no binário e fingir que deu certo.
 
-Quando o resultado não cabe no campo, um painel mostra o número inteiro
-agrupado e a expansão em potências de 2 que chega até ele.
+A parte de que eu não quis abrir mão: **não tem teto**. Cola um número de 300
+dígitos e a resposta sai cravada, sem arredondamento simpático no meio. E se o
+resultado não couber no campo, abre um painel com o número inteiro agrupado e a
+soma de potências de 2 que chega até ele.
 
-## Interface
+A interface é toda em português, de propósito.
 
-Tema claro e escuro, escolha persistida e aplicada antes do primeiro paint.
-Cards com relevo e inclinação seguindo o cursor, desligada em toque e sob
-`prefers-reduced-motion`.
+## O visual
+
+Tema claro e escuro, com a sua escolha guardada e aplicada antes do primeiro
+paint — sem aquele flash branco na hora de carregar. Os cards têm relevo de
+verdade e inclinam acompanhando o cursor; no toque isso não faz sentido, então
+some, e quem pediu `prefers-reduced-motion` não vê nada se mexendo.
 
 <!-- Para exibir as capturas, coloque os dois arquivos em public/ e troque
      este comentário pelo bloco abaixo:
@@ -42,34 +47,31 @@ Cards com relevo e inclinação seguindo o cursor, desligada em toque e sob
 | <img src="./public/screenshot-light.png" alt="Tema claro" /> | <img src="./public/screenshot-dark.png" alt="Tema escuro" /> |
 -->
 
-## Como foi construído
+## Por dentro
 
-**Precisão com `BigInt`.** Toda conversão passa por `BigInt`, então não existe
-teto de tamanho nem arredondamento: 64 bits ligados devolvem
-`18446744073709551615` exato. A validação da entrada acompanha o modo, então
-o modo binário aceita apenas `0` e `1`.
+Quatro escolhas que eu faria de novo.
 
-**Resultado derivado, não estado.** O valor convertido é calculado no render a
-partir da entrada e do modo, sem `useState` nem `useEffect` próprios. Um
-estado a menos para manter em sincronia, e o React Compiler memoiza a
-derivação.
+**`BigInt` do começo ao fim.** É o que garante que 64 bits ligados voltem
+`18446744073709551615` cravado. Com número comum, os últimos dígitos viram
+enfeite. A validação da entrada acompanha o modo, então binário aceita `0` e
+`1` e mais nada.
 
-**O tema alcança o relevo.** As cores das sombras vivem em variáveis CSS
-redefinidas em `.dark`, então trocar de tema muda também o relevo dos cards, e
-não só fundo e texto — um `box-shadow` de valor arbitrário não é alcançável
-por variante `dark:`.
+**O resultado é derivado, não é estado.** Ele sai de uma conta no render, a
+partir da entrada e do modo. Sem `useState`, sem `useEffect`. Um estado a menos
+para manter sincronizado é um bug a menos para caçar depois — e o React
+Compiler memoiza a conta sozinho.
 
-**Largura de conteúdo compartilhada.** `--content-max` define a largura e é
-usada pela linha de campos, pela tabela e pelo painel. A linha é uma grade
-`1fr auto 1fr`, então ocupa essa largura em vez de deduzi-la da soma dos
-filhos.
+**O tema alcança o relevo.** Trocar de tema aqui não muda só fundo e texto: as
+cores das sombras moram em variáveis CSS redefinidas em `.dark`, então o relevo
+dos cards troca junto. Um `box-shadow` de valor arbitrário nenhuma variante
+`dark:` consegue alcançar.
 
-**Ícones de duas fontes.** [Lucide](https://lucide.dev/) para interface e
-[Simple Icons](https://simpleicons.org/) para as marcas, porque o Lucide 1.x
-removeu todos os ícones de marca. A LinkedIn é desenhada à mão: o Simple
-Icons a removeu por pedido de titular.
+**Uma largura, três blocos.** `--content-max` manda na linha de campos, na
+tabela e no painel. A linha é uma grade `1fr auto 1fr`, então ela ocupa essa
+largura em vez de deduzir da soma dos filhos — que é como as bordas de dois
+blocos deixam de bater sem ninguém perceber.
 
-## Stack
+## Com o que foi feito
 
 | | | |
 |---|---|---|
@@ -81,7 +83,7 @@ Icons a removeu por pedido de titular.
 | [Vitest](https://vitest.dev/) | 4.1 | Testes |
 | [Bun](https://bun.sh/) | 1.2 | Gerenciador de pacotes |
 
-## Rodando
+## Rodando na sua máquina
 
 ```bash
 git clone https://github.com/dev-kohako/BinTwoDec.git
@@ -90,8 +92,8 @@ bun install
 bun dev
 ```
 
-Disponível em `http://localhost:5173`. Funciona igual com `npm`, mas o
-lockfile versionado é o do Bun.
+Abre em `http://localhost:5173`. Funciona igual com `npm` — só saiba que o
+lockfile versionado aqui é o do Bun.
 
 ## Scripts
 
@@ -100,25 +102,27 @@ lockfile versionado é o do Bun.
 | `bun dev` | Dev server com HMR |
 | `bun run build` | Type check e build de produção em `dist/` |
 | `bun run preview` | Serve o build localmente |
-| `bun run lint` | ESLint, incluindo as regras do React Compiler |
-| `bun test` | Suíte de testes |
+| `bun run lint` | ESLint, com as regras do React Compiler |
+| `bun test` | Roda os testes |
 | `bun run test:watch` | Testes em modo watch |
 
 ## Testes
 
-A lógica de conversão vive isolada em `src/lib/conversion.ts`, sem React, e é
-onde os testes se concentram. Rodam em ambiente node, sem DOM.
+A conta de conversão mora sozinha em `src/lib/conversion.ts`, sem React
+nenhum, e é ali que os testes batem. Rodam em node, sem DOM, e terminam antes
+de você tirar a mão do teclado.
 
 ```bash
 bun test
 ```
 
-Os casos-limite estão fixados: dígito fora do alfabeto no modo binário,
-valores acima de `Number.MAX_SAFE_INTEGER`, entradas muito longas, entrada
-vazia e zeros à esquerda. O round-trip usa gerador com semente fixa, e não
-`Math.random`, para que uma falha continue reproduzível na execução seguinte.
+O que está fixado são os cantos onde esse tipo de código costuma escorregar:
+dígito fora do alfabeto no modo binário, valores acima de
+`Number.MAX_SAFE_INTEGER`, entrada gigante, entrada vazia e zeros à esquerda. O
+round-trip usa gerador com semente fixa em vez de `Math.random`, senão uma
+falha aparece hoje e desaparece amanhã.
 
-## Estrutura
+## Onde fica o quê
 
 ```
 src/
@@ -131,13 +135,17 @@ src/
 └── index.css       tema, variáveis de relevo e a classe .card-3d
 ```
 
+Se você veio pelo código e quer ver só uma coisa, veja
+[`src/lib/conversion.ts`](src/lib/conversion.ts). É o coração e não passa de
+cem linhas.
+
 O Tailwind 4 dispensa `tailwind.config`: tema e variantes ficam em
-`src/index.css`, via `@theme` e `@custom-variant`.
+`src/index.css`, com `@theme` e `@custom-variant`.
 
 ## Deploy
 
-Publicado na [Vercel](https://bin-two-dec.vercel.app/), com build automático
-a cada push na `main`.
+Está na [Vercel](https://bin-two-dec.vercel.app/), rebuildando a cada push na
+`main`.
 
 | | |
 |---|---|
@@ -147,10 +155,14 @@ a cada push na `main`.
 
 ## Licença
 
-[MIT](LICENSE).
+[MIT](LICENSE) — pega, usa, modifica. Se te ajudou, me conta.
 
-## Autor
+## Quem fez
 
-**Joseph Kawe** — [GitHub](https://github.com/dev-kohako) ·
+**Joseph Kawe**, sob a marca KWK.
+
+[GitHub](https://github.com/dev-kohako) ·
 [LinkedIn](https://www.linkedin.com/in/josephkawe/) ·
+[Instagram](https://www.instagram.com/kohako.dev/) ·
+[YouTube](https://www.youtube.com/@dev_kohako) ·
 [Bento](https://bento.me/kohako)


### PR DESCRIPTION
O conteúdo estava certo mas soava como documentação de biblioteca, sem nada de quem escreveu. Mesma substância, agora em primeira pessoa e com ritmo de conversa.

**Antes:** "Converte números entre base 2 e base 10 nos dois sentidos, com validação de entrada dependente do modo e precisão arbitrária."

**Agora:** "Você digita um número, ele devolve na outra base. E o campo só aceita o que faz sentido no modo em que está — nada de deixar você digitar `7` no binário e fingir que deu certo."

O que mudou:

- títulos deixam de ser rótulos genéricos: **Em resumo**, **O visual**, **Por dentro**, **Com o que foi feito**, **Rodando na sua máquina**, **Onde fica o quê**, **Quem fez**
- cada decisão ganha o motivo em linguagem direta — "um estado a menos para manter sincronizado é um bug a menos para caçar depois"
- a semente fixa nos testes ganha a consequência prática: "senão uma falha aparece hoje e desaparece amanhã"
- entra um atalho para quem chega pelo código: leia só `src/lib/conversion.ts`, que tem **93 linhas** (medido)
- registra que a interface é em português **de propósito**, escolha que estava invisível
- Instagram e YouTube entram no contato, que só tinha GitHub e LinkedIn; assinatura menciona a marca KWK

## Sobre o limite

**Nenhum fato biográfico foi inventado.** O texto afirma apenas coisas verificáveis no próprio repositório — não há "sou apaixonado por", nem motivação de criação, nem história pessoal, porque isso eu não teria como saber e não cabe chutar num README público com o nome do autor embaixo.

Os dois links novos foram conferidos (ambos 200) e a contagem de linhas citada foi medida.

Aplicado nos dois idiomas.