### PR TITLE
chore: ignore the vercel cli link directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.vercel
+.env*


### PR DESCRIPTION
`vercel link` writes `.vercel/` with the project id and a pulled OIDC token, and appends these two lines itself. Nothing env-related is tracked in this repository, so the broad `.env*` costs nothing here.